### PR TITLE
Detect NowPlaying as screensaver

### DIFF
--- a/src/squeezeplay/share/applets/ScreenSavers/ScreenSaversApplet.lua
+++ b/src/squeezeplay/share/applets/ScreenSavers/ScreenSaversApplet.lua
@@ -73,6 +73,7 @@ function init(self, ...)
 
 	self.active = {}
 	self.demoScreensaver = nil
+	self.isScreenSaverActive = false
 
 	-- wait for at least a minute after we start before activating a screensaver,
 	-- otherwise the screensaver may have started when you exit the bootscreen
@@ -175,6 +176,7 @@ function init(self, ...)
 	Framework:addListener(ACTION | EVENT_SCROLL | EVENT_MOUSE_PRESS | EVENT_MOUSE_HOLD | EVENT_MOUSE_DRAG,
 		function(event)
 
+			self.isScreenSaverActive = false
 			-- screensaver is not active
 			if #self.active == 0 then
 				return EVENT_UNUSED
@@ -291,6 +293,7 @@ function _activate(self, the_screensaver, force, isServerRequest)
 		if instance[screensaver.method](instance, force, screensaver.methodParam) ~= false then
 			log:info("activating " .. screensaver.applet .. " screensaver")
 		end
+		self.isScreenSaverActive = true
 	-- special case for screensaver of NONE
 	else
 		log:info('There is no screensaver applet available for this mode')
@@ -591,7 +594,7 @@ end
 
 --service method
 function isScreensaverActive(self)
-	return self.active and #self.active > 0
+	return self.isScreenSaverActive
 end
 
 --service method
@@ -599,7 +602,11 @@ function deactivateScreensaver(self)
 
 	-- close all screensaver windows -0 do oldActive swap to avoid deleting iterated values when there is more than one window
 	local oldActive = self.active
-
+	
+	-- also set the state to false here, because this function could also be called externally through a service call
+	-- It's not enough to set it to false only here, since the addListener() events test for #self.active == 0 and exit if true
+	-- the now playing screen saver is not a screen saver, so the addListener() events exits there, and never call this function
+	self.isScreenSaverActive = false
 	if #oldActive == 0 then
 		-- screensaver is not active
 		return


### PR DESCRIPTION
This is a patch I wrote a very long time ago, and is related to (but not required for) the separate brightness settings for playing/stopped. A patch is available in the repo http://server.vijge.net/static/squeezebox/repo-beta.xml and can be installed using Patch Installer.

Description I wrote about it at the time (2012):

> The NowPlaying screen is not implemented as an official screen saver. Part of the ReduceBrightness plugin depends on the detection of the screen saver. If you set the screen saver to NowPlaying, it will always detect that the screen saver is not running. This has been reported as a bug, and a fix is supplied. That same fix can already be applied to Squeezebox by applying this patch.

This was reported as a bug in the bugzilla tracker as http://bugs.slimdevices.com/show_bug.cgi?id=17916 but it is no longer available. Forum thread about this patch is at https://forums.slimdevices.com/showthread.php?93906-Detecting-screen-saver-with-now-playing-screen-saver