### PR TITLE
Separate brightness settings for playing/stopped

### DIFF
--- a/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyApplet.lua
+++ b/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyApplet.lua
@@ -25,6 +25,7 @@ local Checkbox               = require("jive.ui.Checkbox")
 local Framework              = require("jive.ui.Framework")
 local Group                  = require("jive.ui.Group")
 local Icon                   = require("jive.ui.Icon")
+local Button                 = require("jive.ui.Button")
 local Event                  = require("jive.ui.Event")
 local Label                  = require("jive.ui.Label")
 local Popup                  = require("jive.ui.Popup")
@@ -36,6 +37,7 @@ local Slider                 = require("jive.ui.Slider")
 local Window                 = require("jive.ui.Window")
 local RadioGroup             = require("jive.ui.RadioGroup")
 local RadioButton            = require("jive.ui.RadioButton")
+local Checkbox               = require("jive.ui.Checkbox")
 
 local debug                  = require("jive.utils.debug")
 
@@ -203,9 +205,18 @@ function init(self)
 				if not self:isScreenOff() then
 					self:doAutomaticBrightnessTimer()
 				end
+			else
+				if self.powerState == "ACTIVE" then
+					if self:getBrightness() < settings.brightness then
+						self:setBrightness( settings.brightness)
+					end
+				end
 			end
 		end)
 	brightnessTimer:start()
+	
+	-- reduce brightness on screensaver
+	self:initReduceBrightnessOnScreenSaver()
 
 	-- status bar updates
 	local updateTask = Task("statusbar", self, _updateTask)
@@ -474,8 +485,24 @@ function doAutomaticBrightnessTimer(self)
 	end
 
 	-- Make sure bright Cur stays above minimum
-	if brightMin > brightCur then
-		brightCur = brightMin
+	--if brightMin > brightCur then
+	--	brightCur = brightMin
+	--end
+	
+	-- Screen saver is not active active OR playing and the always active setting is on
+	-- use active brightness settings
+	if appletManager:callService("isScreensaverActive") == false or (_getMode() == "whenPlaying" and settings.brightnessActiveScreenSaver == true) then
+		if brightCur > settings.brightnessActive then
+			brightCur = settings.brightnessActive
+		elseif brightCur < settings.brightnessMinimumActive then
+			brightCur = settings.brightnessMinimumActive
+		end
+	else
+		if brightCur > settings.brightnessScreenSaver then
+			brightCur = settings.brightnessScreenSaver
+		elseif brightCur < settings.brightnessMinimumScreenSaver then
+			brightCur = settings.brightnessMinimumScreenSaver
+		end
 	end
 
 	-- Set Brightness
@@ -528,7 +555,7 @@ function _setBrightness(self, level)
 
 	-- Gradually reduce display brightness in IDLE mode when over half brightness
 	if self.powerState == "IDLE" then
-		if level > (MAX_BRIGHTNESS_LEVEL / 2) then
+		if level > (MAX_BRIGHTNESS_LEVEL / 2) and settings.disableDimToSaveScreen == false then
 			level = level - math.floor(10 * (level - (MAX_BRIGHTNESS_LEVEL / 2)) / (MAX_BRIGHTNESS_LEVEL / 2))
 		end
 	end
@@ -1056,7 +1083,7 @@ function settingsMinBrightnessShow (self, menuItem)
 --			log:info("Value: " .. value)
 
 			-- Set to automatic when changing minimal brightness
-			settings.brightnessControl = "automatic"
+			--settings.brightnessControl = "automatic"
 
 			if value < MIN_BRIGHTNESS_LEVEL then
 				value = MIN_BRIGHTNESS_LEVEL
@@ -1118,7 +1145,7 @@ function settingsBrightnessShow (self, menuItem)
 			settings.brightness = value
 
 			-- If user modifies manual brightness - switch to manaul brightness
-			settings.brightnessControl = "manual"
+			--settings.brightnessControl = "manual"
 
 			local bright = value
 
@@ -1168,6 +1195,7 @@ function settingsBrightnessControlShow(self, menuItem)
 			style = "item_choice",
 			check = RadioButton("radio", group, function(event, menuItem)
 						settings.brightnessControl = "automatic"
+						screensaverTimer:stop()
 					end,
 					settings.brightnessControl == "automatic")
 		},
@@ -1176,9 +1204,24 @@ function settingsBrightnessControlShow(self, menuItem)
 			style = "item_choice",
 			check = RadioButton("radio", group, function(event, menuItem)
 						settings.brightnessControl = "manual"
+						screensaverTimer:start()
 						self:setBrightness(settings.brightness)
 					end,
 					settings.brightnessControl == "manual")
+		},
+		{
+			text = self:string("BSP_BRIGHTNESS_DISABLE_SCREEN_SAFE"),
+			style = "item_choice",
+                        check = Checkbox( "checkbox",
+				function( _, isSelected)
+                                	if isSelected then
+						settings.disableDimToSaveScreen = true
+					else
+						settings.disableDimToSaveScreen = false
+					end
+				end,
+				settings.disableDimToSaveScreen
+				)
 		}
 	})
 
@@ -1200,6 +1243,573 @@ function free(self)
 	return false
 end
 
+--[[
+
+Reduce brightness when screensaver is active
+Patch by Daniel Vijge (daniel@vijge.net)
+Version 1.3
+
+Version history:
+version 1.3 (26-11-2012):
+Setting use active brightness when playing was not saved correctly
+version 1.2 (21-08-2012):
+Added option to disable dimmer to safe screen life time (use with caution!)
+version 0.4 (29-02-2012):
+Added automatic brightness control options
+version 0.3 (24-11-2011):
+WhenOff mode did not work
+version 0.2 (31-03-2011):
+Increase brightness when play is started through external controller
+version 0.1 (27-03-2011): 
+Initial release
+
+]]--
+
+function initReduceBrightnessOnScreenSaver(self)
+	-- initial settings
+	local settings = self:getSettings()
+	
+	settings.dimWhenPlaying = _getDefaultSetting(settings.dimWhenPlaying, false)
+	settings.dimWhenStopped = _getDefaultSetting(settings.dimWhenStopped, true)
+	settings.dimWhenOff = _getDefaultSetting(settings.dimWhenOff, true)
+	settings.brightnessActiveScreenSaver = _getDefaultSetting(settings.brightnessActiveScreenSaver, true)
+	
+	settings.brightnessActive = _getDefaultSetting(settings.brightnessActive, settings.brightness)
+	settings.brightnessMinimumActive = _getDefaultSetting(settings.brightnessMinimumActive, settings.brightnessMinimal)
+	settings.brightnessScreenSaver = _getDefaultSetting(settings.brightnessScreenSaver, settings.brightness)
+	settings.brightnessMinimumScreenSaver = _getDefaultSetting(settings.brightnessMinimumScreenSaver, settings.brightnessMinimal)
+	
+	settings.disableDimToSaveScreen = _getDefaultSetting(settings.disableDimToSaveScreen, false)
+
+	-- this is the timer for manual brightness control
+	screensaverTimer = Timer(5000, 
+		function()
+			if appletManager:callService("isScreensaverActive") then
+				if self:getBrightness() > settings.brightnessMinimal then	
+					if getReduceBrightnessOnScreenSaverSetting() then					
+						self:setBrightness( settings.brightnessMinimal )
+					end
+				end
+			end
+
+			-- this is weird, but we need this to increase the brightness when
+			-- a play command is given using a external interface (controller, web,
+			-- phone, CLI). Those do not register an action event that addListener()
+			-- on line 221 responds to.
+			if _getMode() == "whenPlaying" then
+				if not settings.dimWhenPlaying then
+					if self:getBrightness() == settings.brightnessMinimal then
+						self:setBrightness( settings.brightness )
+					end
+				end
+			end
+		end)
+	
+	-- if brightness control is manual, start the timer
+	if settings.brightnessControl == "manual" then
+		screensaverTimer:start()
+	end
+end
+
+function _getDefaultSetting(setting, default)
+	if setting == nil then
+		return default
+	else
+		return setting
+	end
+end
+		
+-- get the state of the squeezebox, taken from ScreenSaver applet
+function _getMode(self)
+	local player = appletManager:callService("getCurrentPlayer")
+	if jiveMain:getSoftPowerState() == "off" and System:hasSoftPower() then
+		return 'whenOff'
+	else
+		if player and player:getPlayMode() == "play" then
+			return 'whenPlaying'
+		end
+	end
+	return 'whenStopped'
+end
+
+-- should the brightness be reduced in the current playing state?
+function getReduceBrightnessOnScreenSaverSetting(self)
+	local mode = _getMode()
+	if mode == "whenPlaying" then
+		return settings.dimWhenPlaying
+	elseif mode == "whenStopped" then
+		return settings.dimWhenStopped
+	elseif mode == "whenOff" then
+		return settings.dimWhenOff
+	else
+		-- this should not happen, but just to be safe...
+		return false
+	end
+end
+
+function menuAutomaticBrightness(self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_AUTOMATIC"), squeezeboxjiveTitleStyle)
+	
+	local settings = self:getSettings()
+	
+	local menu = SimpleMenu( "menu", {
+					{
+						text = self:string("BSP_BRIGHTNESS_ACTIVE_MAXIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderActive(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_ACTIVE_MINIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderActiveMinimum(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_SCREENSAVER_MAXIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderScreenSaver(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_SCREENSAVER_MINIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderScreenSaverMinimum(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_ACTIVE_WHEN_PLAYING"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.brightnessActiveScreenSaver = true
+									else
+										settings.brightnessActiveScreenSaver = false
+									end
+								end,
+								settings.brightnessActiveScreenSaver
+							)
+					},
+					
+				})
+				
+	window:addListener(EVENT_WINDOW_POP,
+		function()
+			self:storeSettings()
+		end
+	)
+	
+	window:addWidget(menu)
+	window:show()
+end
+
+function menuManualBrightness(self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_MANUAL"), squeezeboxjiveTitleStyle)
+	
+	local menu = SimpleMenu( "menu", {
+					{
+						text = self:string("BSP_BRIGHTNESS_MANUAL"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessShow(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_MIN"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsMinBrightnessShow(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_SCREENSAVER"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:menuReduceBrightness()
+						end 
+					},
+				})
+	window:addWidget(menu)
+	window:show()
+end
+
+function menuReduceBrightness(self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_SCREENSAVER"), squeezeboxjiveTitleStyle)
+	local settings = self:getSettings()
+
+	local menu = SimpleMenu( "menu", {
+					{
+						text = self:string("BSP_BRIGHTNESS_DIMWHENPLAYING"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.dimWhenPlaying = true
+									else
+										settings.dimWhenPlaying = false
+									end
+								end,
+								settings.dimWhenPlaying
+							)
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_DIMWHENSTOPPED"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.dimWhenStopped = true
+									else
+										settings.dimWhenStopped = false
+									end
+								end,
+								settings.dimWhenStopped
+							)
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_DIMWHENOFF"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.dimWhenOff = true
+									else
+										settings.dimWhenOff = false
+									end
+								end,
+								settings.dimWhenOff
+							)
+					},
+				})
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()
+			self:storeSettings()
+		end
+	)
+
+	window:addWidget(menu)
+	window:show()
+
+end
+
+function settingsBrightnessSliderActive (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_ACTIVE_MAXIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessActive
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessActive = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true for 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
+
+function settingsBrightnessSliderActiveMinimum (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_ACTIVE_MINIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessMinimumActive
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessMinimumActive = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true fsettingsBrightnessSliderScreenSaverMinimumor 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
+
+function settingsBrightnessSliderScreenSaver (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_SCREENSAVER_MAXIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessScreenSaver
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessScreenSaver = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true for 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
+
+function settingsBrightnessSliderScreenSaverMinimum (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_SCREENSAVER_MINIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessMinimumScreenSaver
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessMinimumScreenSaver = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true for 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
 
 --[[
 

--- a/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyMeta.lua
+++ b/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyMeta.lua
@@ -82,9 +82,10 @@ function registerApplet(meta)
 	jiveMain:setDefaultSkin("QVGAlandscapeSkin")
 
 	-- settings
-	jiveMain:addItem(meta:menuItem('brightnessSetting', 'settingsBrightness', "BSP_BRIGHTNESS_MANUAL", function(applet, ...) applet:settingsBrightnessShow(...) end, _, _, "hm_settingsBrightness"))
-	jiveMain:addItem(meta:menuItem('minBrightnessSetting', 'settingsBrightness', "BSP_BRIGHTNESS_MIN", function(applet, ...) applet:settingsMinBrightnessShow(...) end)) 
 	jiveMain:addItem(meta:menuItem('brightnessSettingControl', 'settingsBrightness', "BSP_BRIGHTNESS_CTRL", function(applet, ...) applet:settingsBrightnessControlShow(...) end, _, _, "hm_settingsBrightness"))
+	jiveMain:addItem(meta:menuItem('menuAutomaticBrightness', 'settingsBrightness', "BSP_BRIGHTNESS_AUTOMATIC", function(applet, ...) applet:menuAutomaticBrightness(...) end))
+	jiveMain:addItem(meta:menuItem('menuManualBrightness', 'settingsBrightness', "BSP_BRIGHTNESS_MANUAL", function(applet, ...) applet:menuManualBrightness(...) end))
+	
 
 	-- services
 	meta:registerService("getBrightness")

--- a/src/squeezeplay_baby/share/applets/SqueezeboxBaby/strings.txt
+++ b/src/squeezeplay_baby/share/applets/SqueezeboxBaby/strings.txt
@@ -124,19 +124,19 @@ BSP_BRIGHTNESS_MANUAL
 	SV	Manuell ljusstyrka
 
 BSP_BRIGHTNESS_MIN
-	CS	Minimální jas (Auto)
-	DA	Mindste lysstyrke (automatisk)
-	DE	Minimale Helligkeit (automatisch)
-	EN	Minimal Brightness (Auto)
-	ES	Brillo mínimo (automático)
-	FI	Vähimmäiskirkkaus (autom.)
-	FR	Luminosité minimale (Auto)
-	IT	Luminosità minima (auto)
-	NL	Minimale helderheid (automatisch)
-	NO	Minimal lysstyrke (Automatisk)
-	PL	Minimalna jasność (automatycznie)
-	RU	Минимальная яркость (Авто)
-	SV	Minsta ljusstyrka (auto)
+	CS	Minimální jas
+	DA	Mindste lysstyrke
+	DE	Minimale Helligkeit
+	EN	Minimal Brightness
+	ES	Brillo mínimo
+	FI	Vähimmäiskirkkaus
+	FR	Luminosité minimale
+	IT	Luminosità minima
+	NL	Minimale helderheid
+	NO	Minimal lysstyrke
+	PL	Minimalna jasność
+	RU	Минимальная яркость
+	SV	Minsta ljusstyrka
 
 BSP_BRIGHTNESS_MIN_ADJUST_HELP
 	CS	K nastavení minimálního jasu použijte kolečko.
@@ -242,4 +242,154 @@ BETA_HARDWARE_EUTHANIZE
 	PL	To jest urządzenie przedprodukcyjne, wersja sprzętowa %s.\n\nTo urządzenie nie jest już obsługiwane, prosimy zwrócić je do firmy Logitech.
 	RU	Это предварительная версия устройства, выпуск оборудования %s.\n\nЭто устройство больше не поддерживается, верните его в Logitech.
 	SV	Det här är en prototyp av maskinvaran med versionsbeteckning %s.\n\nEnheten stöds inte längre och ska återlämnas till Logitech.
+
+BSP_BRIGHTNESS_SCREENSAVER
+	CS	Reduce on screen saver
+	DA	Reduce on screen saver
+	DE	Reduce on screen saver
+	EN	Reduce on screen saver
+	ES	Reduce on screen saver
+	FI	Reduce on screen saver
+	FR	Reduce on screen saver
+	IT	Reduce on screen saver
+	NL	Verminder bij schermbeveiliging
+	NO	Reduce on screen saver
+	PL	Reduce on screen saver
+	RU	Reduce on screen saver
+	SV	Reduce on screen saver
+
+BSP_BRIGHTNESS_DIMWHENPLAYING
+	CS	Při přehrávání
+	DA	Under afspilning
+	DE	Bei Wiedergabe
+	EN	When playing
+	ES	Al reproducir
+	FI	Toistettaessa
+	FR	Pendant la lecture
+	IT	Durante la riproduzione
+	NL	Tijdens afspelen
+	NO	Under avspilling
+	PL	Podczas odtwarzania
+	RU	При воспроизведении
+	SV	Vid uppspelning
+
+BSP_BRIGHTNESS_DIMWHENSTOPPED
+	CS	Při zastavení
+	DA	Når den er stoppet
+	DE	Wenn angehalten
+	EN	When stopped
+	ES	Al detener
+	FI	Keskeytettynä
+	FR	A l'arrêt
+	IT	Quando la riproduzione è interrotta
+	NL	Wanneer gestopt
+	NO	Ved stopp
+	PL	Po zatrzymaniu
+	RU	При остановке
+	SV	I stoppat läge
+
+BSP_BRIGHTNESS_DIMWHENOFF
+	CS	Při vypnutí
+	DA	Når den er slukket
+	DE	Wenn aus
+	EN	When off
+	ES	Al apagar
+	FI	Laitteen ollessa pois päältä
+	FR	En état éteint
+	IT	Se disattivato
+	NL	Wanneer uit
+	NO	Av
+	PL	Po wyłączeniu
+	RU	При выкл.
+	SV	I avstängt läge
+
+BSP_BRIGHTNESS_ACTIVE_MAXIMUM
+	CS	Maximum brightness (active)
+	DA	Maximum brightness (active)
+	DE	Maximum brightness (active)
+	EN	Maximum brightness (active)
+	ES	Maximum brightness (active)
+	FI	Maximum brightness (active)
+	FR	Maximum brightness (active)
+	IT	Maximum brightness (active)
+	NL	Maximale helderheid (actief)
+	NO	Maximum brightness (active)
+	PL	Maximum brightness (active)
+	RU	Maximum brightness (active)
+	SV	Maximum brightness (active)
+	
+BSP_BRIGHTNESS_ACTIVE_MINIMUM
+	CS	Minimum brightness (active)
+	DA	Minimum brightness (active)
+	DE	Minimum brightness (active)
+	EN	Minimum brightness (active)
+	ES	Minimum brightness (active)
+	FI	Minimum brightness (active)
+	FR	Minimum brightness (active)
+	IT	Minimum brightness (active)
+	NL	Minimale helderheid (actief)
+	NO	Minimum brightness (active)
+	PL	Minimum brightness (active)
+	RU	Minimum brightness (active)
+	SV	Minimum brightness (active)
+	
+BSP_BRIGHTNESS_SCREENSAVER_MAXIMUM
+	CS	Maximum brightness (screen saver)
+	DA	Maximum brightness (screen saver)
+	DE	Maximum brightness (screen saver)
+	EN	Maximum brightness (screen saver)
+	ES	Maximum brightness (screen saver)
+	FI	Maximum brightness (screen saver)
+	FR	Maximum brightness (screen saver)
+	IT	Maximum brightness (screen saver)
+	NL	Maximale helderheid (schermbeveiliging)
+	NO	Maximum brightness (screen saver)
+	PL	Maximum brightness (screen saver)
+	RU	Maximum brightness (screen saver)
+	SV	Maximum brightness (screen saver)
+	
+BSP_BRIGHTNESS_SCREENSAVER_MINIMUM
+	CS	Minimum brightness (screen saver)
+	DA	Minimum brightness (screen saver)
+	DE	Minimum brightness (screen saver)
+	EN	Minimum brightness (screen saver)
+	ES	Minimum brightness (screen saver)
+	FI	Minimum brightness (screen saver)
+	FR	Minimum brightness (screen saver)
+	IT	Minimum brightness (screen saver)
+	NL	Minimale helderheid (schermbeveiliging)
+	NO	Minimum brightness (screen saver)
+	PL	Minimum brightness (screen saver)
+	RU	Minimum brightness (screen saver)
+	SV	Minimum brightness (screen saver)
+	
+BSP_BRIGHTNESS_ACTIVE_WHEN_PLAYING
+	CS	Use active brightness when playing
+	DA	Use active brightness when playing
+	DE	Use active brightness when playing
+	EN	Use active brightness when playing
+	ES	Use active brightness when playing
+	FI	Use active brightness when playing
+	FR	Use active brightness when playing
+	IT	Use active brightness when playing
+	NL	Gebruik actieve helderheid bij afspelen
+	NO	Use active brightness when playing
+	PL	Use active brightness when playing
+	RU	Use active brightness when playing
+	SV	Use active brightness when playing
+
+BSP_BRIGHTNESS_DISABLE_SCREEN_SAFE
+	CS	Disable gradual dim when idle (not recommended!)
+	DA	Disable gradual dim when idle (not recommended!)
+	DE	Disable gradual dim when idle (not recommended!) 
+	EN	Disable gradual dim when idle (not recommended!) 
+	ES	Disable gradual dim when idle (not recommended!) 
+	FI	Disable gradual dim when idle (not recommended!) 
+	FR	Disable gradual dim when idle (not recommended!) 
+	IT	Disable gradual dim when idle (not recommended!) 
+	NL	Helderheid voor scherm niet aanpassen (niet aanbevolen!)
+	NO	Disable gradual dim when idle (not recommended!) 
+	PL	Disable gradual dim when idle (not recommended!) 
+	RU	Disable gradual dim when idle (not recommended!) 
+	SV	Disable gradual dim when idle (not recommended!) 
 

--- a/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/SqueezeboxFab4Applet.lua
+++ b/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/SqueezeboxFab4Applet.lua
@@ -34,6 +34,7 @@ local Slider                 = require("jive.ui.Slider")
 local RadioGroup             = require("jive.ui.RadioGroup")
 local RadioButton            = require("jive.ui.RadioButton")
 local Window                 = require("jive.ui.Window")
+local Checkbox               = require("jive.ui.Checkbox")
 
 local debug                  = require("jive.utils.debug")
 
@@ -152,6 +153,9 @@ function init(self)
 		end)
 	brightnessTimer:start()
 	
+	-- reduce brightness on screensaver
+	self:initReduceBrightnessOnScreenSaver()
+	
 	-- status bar updates
 	local updateTask = Task("statusbar", self, _updateTask)
 	updateTask:addTask(UPDATE_WIRELESS)
@@ -236,7 +240,11 @@ function initBrightness(self)
 			-- Set to >0 means we're ACTIVE
 			brightOverride = BRIGHTNESS_OVERRIDE
 			-- ACTIVE: Increase brightness
-			self:setBrightness( self:getBrightness())
+			if settings.brightnessControl == "manual" then
+				self:setBrightness( settings.brightness)
+			else
+				self:setBrightness( self:getBrightness())
+			end
 			return EVENT_UNUSED
 		end
 		,true)		
@@ -378,16 +386,33 @@ function doAutomaticBrightnessTimer(self)
 	end
 
 	-- Make sure bright Cur stays above minimum
-	if brightMin > brightCur then
-		brightCur = brightMin
-	end
+	--if brightMin > brightCur then
+	--	brightCur = brightMin
+	--end
 
 	-- ACTIVE mode
 	-- As long as the user is touching the screen don't do anything more
 	if brightOverride > 0 then
 		-- count down once per cycle
 		brightOverride = brightOverride - 1
-		return
+		--return
+	end
+	
+	-- Screen saver is not active active OR playing and the always active setting is on
+	-- use active brightness settings
+	if appletManager:callService("isScreensaverActive") == false or (_getMode() == "whenPlaying" and settings.brightnessActiveScreenSaver == true) then
+		if brightCur > settings.brightnessActive then
+			brightCur = settings.brightnessActive
+		elseif brightCur < settings.brightnessMinimumActive then
+			brightCur = settings.brightnessMinimumActive
+		end
+		
+	else
+		if brightCur > settings.brightnessScreenSaver then
+			brightCur = settings.brightnessScreenSaver
+		elseif brightCur < settings.brightnessMinimumScreenSaver then
+			brightCur = settings.brightnessMinimumScreenSaver
+		end
 	end
 
 	-- Set Brightness
@@ -444,7 +469,7 @@ function _setBrightness(self, level)
 	-- Gradually reduce LCD brightness when IDLE and level is over half of maximum brightness
 	--  to increase lifetime of LCD backlight
 	if brightOverride == 0 then
-		if level > (MAX_BRIGHTNESS_LEVEL / 2) then
+		if level > (MAX_BRIGHTNESS_LEVEL / 2) and settings.disableDimToSaveScreen == false then
 			level = level - math.floor(40 * (level - (MAX_BRIGHTNESS_LEVEL / 2)) / (MAX_BRIGHTNESS_LEVEL / 2))
 		end
 	end
@@ -605,7 +630,7 @@ function settingsMinBrightnessShow (self, menuItem)
 --					log:info("Value: " .. value)
 
 					-- Set to automatic when changing minimal brightness
-					settings.brightnessControl = "automatic"
+					--settings.brightnessControl = "automatic"
 					-- Prepare setting to store later
 					settings.brightnessMinimal = value
 					-- Update min value for timer loop
@@ -689,7 +714,7 @@ function settingsBrightnessShow (self, menuItem)
 	local slider = Slider('brightness_slider', 1, 100, level,
 				function(slider, value, done)
 					
-					settings.brightnessControl = "manual"
+					--settings.brightnessControl = "manual"
 					
 					settings.brightness = value
 
@@ -780,6 +805,7 @@ function settingsBrightnessControlShow(self, menuItem)
 			style = "item_choice",
 			check = RadioButton("radio", group, function(event, menuItem)
 						settings.brightnessControl = "automatic"
+						screensaverTimer:stop()
 					end,
 					settings.brightnessControl == "automatic")
 		},	
@@ -788,9 +814,24 @@ function settingsBrightnessControlShow(self, menuItem)
 			style = "item_choice",
 			check = RadioButton("radio", group, function(event, menuItem)
 						settings.brightnessControl = "manual"
+						screensaverTimer:start()
 						self:setBrightness(settings.brightness)
 					end,
 					settings.brightnessControl == "manual")
+		},
+		{
+			text = self:string("BSP_BRIGHTNESS_DISABLE_SCREEN_SAFE"),
+			style = "item_choice",
+                        check = Checkbox( "checkbox",
+				function( _, isSelected)
+                                	if isSelected then
+						settings.disableDimToSaveScreen = true
+					else
+						settings.disableDimToSaveScreen = false
+					end
+				end,
+				settings.disableDimToSaveScreen
+				)
 		}
 	})
 	
@@ -804,7 +845,6 @@ function settingsBrightnessControlShow(self, menuItem)
 	window:show()
 
 end
-
 
 -- Moved here from SqueezeCenter applet since SC applet is not resident
 --  but we need scGuardTimer to survive
@@ -890,6 +930,573 @@ function free(self)
 	return false
 end
 
+--[[
+
+Reduce brightness when screensaver is active
+Patch by Daniel Vijge (daniel@vijge.net)
+Version 1.3
+
+Version history:
+version 1.3 (26-11-2012):
+Setting use active brightness when playing was not saved correctly
+version 1.2 (21-08-2012):
+Added option to disable dimmer to safe screen life time (use with caution!)
+version 0.4 (29-02-2012):
+Added automatic brightness control options
+version 0.3 (24-11-2011):
+WhenOff mode did not work
+version 0.2 (31-03-2011):
+Increase brightness when play is started through external controller
+version 0.1 (27-03-2011): 
+Initial release
+
+]]--
+
+function initReduceBrightnessOnScreenSaver(self)
+	-- initial settings
+	local settings = self:getSettings()
+	
+	settings.dimWhenPlaying = _getDefaultSetting(settings.dimWhenPlaying, false)
+	settings.dimWhenStopped = _getDefaultSetting(settings.dimWhenStopped, true)
+	settings.dimWhenOff = _getDefaultSetting(settings.dimWhenOff, true)
+	settings.brightnessActiveScreenSaver = _getDefaultSetting(settings.brightnessActiveScreenSaver, true)
+	
+	settings.brightnessActive = _getDefaultSetting(settings.brightnessActive, settings.brightness)
+	settings.brightnessMinimumActive = _getDefaultSetting(settings.brightnessMinimumActive, settings.brightnessMinimal)
+	settings.brightnessScreenSaver = _getDefaultSetting(settings.brightnessScreenSaver, settings.brightness)
+	settings.brightnessMinimumScreenSaver = _getDefaultSetting(settings.brightnessMinimumScreenSaver, settings.brightnessMinimal)
+	
+	settings.disableDimToSaveScreen = _getDefaultSetting(settings.disableDimToSaveScreen, false)
+
+	-- this is the timer for manual brightness control
+	screensaverTimer = Timer(5000, 
+		function()
+			if appletManager:callService("isScreensaverActive") then
+				if self:getBrightness() > settings.brightnessMinimal then	
+					if getReduceBrightnessOnScreenSaverSetting() then					
+						self:setBrightness( settings.brightnessMinimal )
+					end
+				end
+			end
+
+			-- this is weird, but we need this to increase the brightness when
+			-- a play command is given using a external interface (controller, web,
+			-- phone, CLI). Those do not register an action event that addListener()
+			-- on line 221 responds to.
+			if _getMode() == "whenPlaying" then
+				if not settings.dimWhenPlaying then
+					if self:getBrightness() == settings.brightnessMinimal then
+						self:setBrightness( settings.brightness )
+					end
+				end
+			end
+		end)
+	
+	-- if brightness control is manual, start the timer
+	if settings.brightnessControl == "manual" then
+		screensaverTimer:start()
+	end
+end
+
+function _getDefaultSetting(setting, default)
+	if setting == nil then
+		return default
+	else
+		return setting
+	end
+end
+		
+-- get the state of the squeezebox, taken from ScreenSaver applet
+function _getMode(self)
+	local player = appletManager:callService("getCurrentPlayer")
+	if jiveMain:getSoftPowerState() == "off" and System:hasSoftPower() then
+		return 'whenOff'
+	else
+		if player and player:getPlayMode() == "play" then
+			return 'whenPlaying'
+		end
+	end
+	return 'whenStopped'
+end
+
+-- should the brightness be reduced in the current playing state?
+function getReduceBrightnessOnScreenSaverSetting(self)
+	local mode = _getMode()
+	if mode == "whenPlaying" then
+		return settings.dimWhenPlaying
+	elseif mode == "whenStopped" then
+		return settings.dimWhenStopped
+	elseif mode == "whenOff" then
+		return settings.dimWhenOff
+	else
+		-- this should not happen, but just to be safe...
+		return false
+	end
+end
+
+function menuAutomaticBrightness(self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_AUTOMATIC"), squeezeboxjiveTitleStyle)
+	
+	local settings = self:getSettings()
+	
+	local menu = SimpleMenu( "menu", {
+					{
+						text = self:string("BSP_BRIGHTNESS_ACTIVE_MAXIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderActive(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_ACTIVE_MINIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderActiveMinimum(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_SCREENSAVER_MAXIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderScreenSaver(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_SCREENSAVER_MINIMUM"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessSliderScreenSaverMinimum(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_ACTIVE_WHEN_PLAYING"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.brightnessActiveScreenSaver = true
+									else
+										settings.brightnessActiveScreenSaver = false
+									end
+								end,
+								settings.brightnessActiveScreenSaver
+							)
+					},
+					
+				})
+				
+	window:addListener(EVENT_WINDOW_POP,
+		function()
+			self:storeSettings()
+		end
+	)
+	
+	window:addWidget(menu)
+	window:show()
+end
+
+function menuManualBrightness(self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_MANUAL"), squeezeboxjiveTitleStyle)
+	
+	local menu = SimpleMenu( "menu", {
+					{
+						text = self:string("BSP_BRIGHTNESS_MANUAL"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsBrightnessShow(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_MIN"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:settingsMinBrightnessShow(menuItem)
+						end 
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_SCREENSAVER"),
+						sound = "WINDOWSHOW",
+						callback = function(event, menuItem)
+							self:menuReduceBrightness()
+						end 
+					},
+				})
+	window:addWidget(menu)
+	window:show()
+end
+
+function menuReduceBrightness(self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_SCREENSAVER"), squeezeboxjiveTitleStyle)
+	local settings = self:getSettings()
+
+	local menu = SimpleMenu( "menu", {
+					{
+						text = self:string("BSP_BRIGHTNESS_DIMWHENPLAYING"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.dimWhenPlaying = true
+									else
+										settings.dimWhenPlaying = false
+									end
+								end,
+								settings.dimWhenPlaying
+							)
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_DIMWHENSTOPPED"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.dimWhenStopped = true
+									else
+										settings.dimWhenStopped = false
+									end
+								end,
+								settings.dimWhenStopped
+							)
+					},
+					{
+						text = self:string("BSP_BRIGHTNESS_DIMWHENOFF"),
+						style = 'item_choice',
+						check = Checkbox( "checkbox",
+								function( _, isSelected)
+									if isSelected then
+										settings.dimWhenOff = true
+									else
+										settings.dimWhenOff = false
+									end
+								end,
+								settings.dimWhenOff
+							)
+					},
+				})
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()
+			self:storeSettings()
+		end
+	)
+
+	window:addWidget(menu)
+	window:show()
+
+end
+
+function settingsBrightnessSliderActive (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_ACTIVE_MAXIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessActive
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessActive = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true for 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
+
+function settingsBrightnessSliderActiveMinimum (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_ACTIVE_MINIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessMinimumActive
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessMinimumActive = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true fsettingsBrightnessSliderScreenSaverMinimumor 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
+
+function settingsBrightnessSliderScreenSaver (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_SCREENSAVER_MAXIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessScreenSaver
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessScreenSaver = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true for 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
+
+function settingsBrightnessSliderScreenSaverMinimum (self, menuItem)
+	local window = Window("text_list", self:string("BSP_BRIGHTNESS_SCREENSAVER_MINIMUM"), squeezeboxjiveTitleStyle)
+
+	local settings = self:getSettings()
+	local level = settings.brightnessMinimumScreenSaver
+
+	local slider = Slider('brightness_slider', 1, 75, level,
+				function(slider, value, done)
+					--log:info("Value: " .. value)
+
+					settings.brightnessMinimumScreenSaver = value
+					
+					-- Make sure preview min brightness does
+					--  not go below actual brightness
+					if value > brightTarget then
+						self:setBrightness( value)
+					else
+						self:setBrightness( math.floor( brightTarget))
+					end
+					
+					-- done is true for 'go' and 'play' but we do not want to leave
+					if done then
+						window:playSound("BUMP")
+						window:bumpRight()
+					end
+				end)
+	slider.jumpOnDown = false
+	slider.dragThreshold = 5
+
+--	window:addWidget(Textarea("help_text", self:string("BSP_BRIGHTNESS_ADJUST_HELP")))
+	window:addWidget(Group('brightness_group', {
+				div1 = Icon('div1'),
+				div2 = Icon('div2'),
+
+
+				down  = Button(
+					Icon('down'),
+					function()
+						local e = Event:new(EVENT_SCROLL, -1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				up  = Button(
+					Icon('up'),
+					function()
+						local e = Event:new(EVENT_SCROLL, 1)
+						Framework:dispatchEvent(slider, e)
+						return EVENT_CONSUME
+					end
+				),
+				slider = slider,
+			}))
+
+	window:addActionListener("page_down", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, 1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+	window:addActionListener("page_up", self,
+				function()
+					local e = Event:new(EVENT_SCROLL, -1)
+					Framework:dispatchEvent(self.volSlider, e)
+					return EVENT_CONSUME
+				end)
+
+
+	window:addListener(EVENT_WINDOW_POP,
+		function()			
+			self:storeSettings()
+		end
+	)
+
+	window:show()
+	return window
+end
 
 --[[
 

--- a/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/SqueezeboxFab4Meta.lua
+++ b/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/SqueezeboxFab4Meta.lua
@@ -82,10 +82,10 @@ function registerApplet(meta)
 	jiveMain:setDefaultSkin("WQVGAsmallSkin")
 
 	-- settings
-	jiveMain:addItem(meta:menuItem('brightnessSetting', 'settingsBrightness', "BSP_BRIGHTNESS_MANUAL", function(applet, ...) applet:settingsBrightnessShow(...) end))
-	jiveMain:addItem(meta:menuItem('minBrightnessSetting', 'settingsBrightness', "BSP_BRIGHTNESS_MIN", function(applet, ...) applet:settingsMinBrightnessShow(...) end))
 	jiveMain:addItem(meta:menuItem('brightnessSettingControl', 'settingsBrightness', "BSP_BRIGHTNESS_CTRL", function(applet, ...) applet:settingsBrightnessControlShow(...) end))
-
+	jiveMain:addItem(meta:menuItem('menuAutomaticBrightness', 'settingsBrightness', "BSP_BRIGHTNESS_AUTOMATIC", function(applet, ...) applet:menuAutomaticBrightness(...) end))
+	jiveMain:addItem(meta:menuItem('menuManualBrightness', 'settingsBrightness', "BSP_BRIGHTNESS_MANUAL", function(applet, ...) applet:menuManualBrightness(...) end))
+	
 	-- services
 	meta:registerService("getBrightness")
 	meta:registerService("setBrightness")

--- a/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/strings.txt
+++ b/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/strings.txt
@@ -169,19 +169,19 @@ BSP_BRIGHTNESS_MANUAL
 	SV	Manuell ljusstyrka
 
 BSP_BRIGHTNESS_MIN
-	CS	Minimální jas (Auto)
-	DA	Mindste lysstyrke (automatisk)
-	DE	Minimale Helligkeit (automatisch)
-	EN	Minimal Brightness (Auto)
-	ES	Brillo mínimo (automático)
-	FI	Vähimmäiskirkkaus (autom.)
-	FR	Luminosité minimale (Auto)
-	IT	Luminosità minima (auto)
-	NL	Minimale helderheid (automatisch)
-	NO	Minimal lysstyrke (Automatisk)
-	PL	Minimalna jasność (automatycznie)
-	RU	Минимальная яркость (Авто)
-	SV	Minsta ljusstyrka (auto)
+	CS	Minimální jas
+	DA	Mindste lysstyrke
+	DE	Minimale Helligkeit
+	EN	Minimal Brightness
+	ES	Brillo mínimo
+	FI	Vähimmäiskirkkaus
+	FR	Luminosité minimale
+	IT	Luminosità minima
+	NL	Minimale helderheid
+	NO	Minimal lysstyrke
+	PL	Minimalna jasność
+	RU	Минимальная яркость
+	SV	Minsta ljusstyrka
 
 BSP_BRIGHTNESS_ADJUST_HELP
 	CS	K nastavení jasu použijte kolečko.
@@ -227,4 +227,153 @@ SERVER_HAS_BEEN_STOPPED_INFO
 	PL	Lokalna usługa muzyczna została zatrzymana ze względu na problem.
 	RU	Локальная музыкальная служба остановлена из-за неполадок.
 	SV	Lokal musiktjänst har stoppats på grund av problem.
+	
+BSP_BRIGHTNESS_SCREENSAVER
+	CS	Reduce on screen saver
+	DA	Reduce on screen saver
+	DE	Reduce on screen saver
+	EN	Reduce on screen saver
+	ES	Reduce on screen saver
+	FI	Reduce on screen saver
+	FR	Reduce on screen saver
+	IT	Reduce on screen saver
+	NL	Verminder bij schermbeveiliging
+	NO	Reduce on screen saver
+	PL	Reduce on screen saver
+	RU	Reduce on screen saver
+	SV	Reduce on screen saver
 
+BSP_BRIGHTNESS_DIMWHENPLAYING
+	CS	Při přehrávání
+	DA	Under afspilning
+	DE	Bei Wiedergabe
+	EN	When playing
+	ES	Al reproducir
+	FI	Toistettaessa
+	FR	Pendant la lecture
+	IT	Durante la riproduzione
+	NL	Tijdens afspelen
+	NO	Under avspilling
+	PL	Podczas odtwarzania
+	RU	При воспроизведении
+	SV	Vid uppspelning
+
+BSP_BRIGHTNESS_DIMWHENSTOPPED
+	CS	Při zastavení
+	DA	Når den er stoppet
+	DE	Wenn angehalten
+	EN	When stopped
+	ES	Al detener
+	FI	Keskeytettynä
+	FR	A l'arrêt
+	IT	Quando la riproduzione è interrotta
+	NL	Wanneer gestopt
+	NO	Ved stopp
+	PL	Po zatrzymaniu
+	RU	При остановке
+	SV	I stoppat läge
+
+BSP_BRIGHTNESS_DIMWHENOFF
+	CS	Při vypnutí
+	DA	Når den er slukket
+	DE	Wenn aus
+	EN	When off
+	ES	Al apagar
+	FI	Laitteen ollessa pois päältä
+	FR	En état éteint
+	IT	Se disattivato
+	NL	Wanneer uit
+	NO	Av
+	PL	Po wyłączeniu
+	RU	При выкл.
+	SV	I avstängt läge
+
+BSP_BRIGHTNESS_ACTIVE_MAXIMUM
+	CS	Maximum brightness (active)
+	DA	Maximum brightness (active)
+	DE	Maximum brightness (active)
+	EN	Maximum brightness (active)
+	ES	Maximum brightness (active)
+	FI	Maximum brightness (active)
+	FR	Maximum brightness (active)
+	IT	Maximum brightness (active)
+	NL	Maximale helderheid (actief)
+	NO	Maximum brightness (active)
+	PL	Maximum brightness (active)
+	RU	Maximum brightness (active)
+	SV	Maximum brightness (active)
+	
+BSP_BRIGHTNESS_ACTIVE_MINIMUM
+	CS	Minimum brightness (active)
+	DA	Minimum brightness (active)
+	DE	Minimum brightness (active)
+	EN	Minimum brightness (active)
+	ES	Minimum brightness (active)
+	FI	Minimum brightness (active)
+	FR	Minimum brightness (active)
+	IT	Minimum brightness (active)
+	NL	Minimale helderheid (actief)
+	NO	Minimum brightness (active)
+	PL	Minimum brightness (active)
+	RU	Minimum brightness (active)
+	SV	Minimum brightness (active)
+	
+BSP_BRIGHTNESS_SCREENSAVER_MAXIMUM
+	CS	Maximum brightness (screen saver)
+	DA	Maximum brightness (screen saver)
+	DE	Maximum brightness (screen saver)
+	EN	Maximum brightness (screen saver)
+	ES	Maximum brightness (screen saver)
+	FI	Maximum brightness (screen saver)
+	FR	Maximum brightness (screen saver)
+	IT	Maximum brightness (screen saver)
+	NL	Maximale helderheid (schermbeveiliging)
+	NO	Maximum brightness (screen saver)
+	PL	Maximum brightness (screen saver)
+	RU	Maximum brightness (screen saver)
+	SV	Maximum brightness (screen saver)
+	
+BSP_BRIGHTNESS_SCREENSAVER_MINIMUM
+	CS	Minimum brightness (screen saver)
+	DA	Minimum brightness (screen saver)
+	DE	Minimum brightness (screen saver)
+	EN	Minimum brightness (screen saver)
+	ES	Minimum brightness (screen saver)
+	FI	Minimum brightness (screen saver)
+	FR	Minimum brightness (screen saver)
+	IT	Minimum brightness (screen saver)
+	NL	Minimale helderheid (schermbeveiliging)
+	NO	Minimum brightness (screen saver)
+	PL	Minimum brightness (screen saver)
+	RU	Minimum brightness (screen saver)
+	SV	Minimum brightness (screen saver)
+	
+BSP_BRIGHTNESS_ACTIVE_WHEN_PLAYING
+	CS	Use active brightness when playing
+	DA	Use active brightness when playing
+	DE	Use active brightness when playing
+	EN	Use active brightness when playing
+	ES	Use active brightness when playing
+	FI	Use active brightness when playing
+	FR	Use active brightness when playing
+	IT	Use active brightness when playing
+	NL	Gebruik actieve helderheid bij afspelen
+	NO	Use active brightness when playing
+	PL	Use active brightness when playing
+	RU	Use active brightness when playing
+	SV	Use active brightness when playing
+
+BSP_BRIGHTNESS_DISABLE_SCREEN_SAFE
+	CS	Disable gradual dim when idle (not recommended!)
+	DA	Disable gradual dim when idle (not recommended!)
+	DE	Disable gradual dim when idle (not recommended!) 
+	EN	Disable gradual dim when idle (not recommended!) 
+	ES	Disable gradual dim when idle (not recommended!) 
+	FI	Disable gradual dim when idle (not recommended!) 
+	FR	Disable gradual dim when idle (not recommended!) 
+	IT	Disable gradual dim when idle (not recommended!) 
+	NL	Helderheid voor scherm niet aanpassen (niet aanbevolen!)
+	NO	Disable gradual dim when idle (not recommended!) 
+	PL	Disable gradual dim when idle (not recommended!) 
+	RU	Disable gradual dim when idle (not recommended!) 
+	SV	Disable gradual dim when idle (not recommended!) 


### PR DESCRIPTION
The Squeezebox Touch/Radio has two brightness settings: manual and automatic. The manual setting always has the same brightness level whether the device is being used, playing, stopped, or off. The automatic settings sets the brightness based on the environment light conditions. It doesn’t really work if you try to control the player in a dark room, and the minimal brightness level is set to a low level, because that the screen would be at the lowest level, and you can’t see a thing. This patch to change this behaviour. It changes the implementation of both automatic and manual setting.

For the automatic setting, it introduces four new brightness settings:

- Active maximum
- Active minimum
- Screen saver maximum
- Screen saver minimum

When the system is active (you touch the screen, or use the remote control) the brightness will remain between the active minimum and maximum. If a screen saver is on, the brightness will remain between the screen saver minimum and maximum. There is an option to always use the active setting when the Squeezebox is playing.

For the manual setting, you can set a manual brightness and a minimal brightness. Manual brightness is the brightness when the system is active, minimum brightness is the brightness when the screen saver is on. There are options to control when the screen should reduce its brightness to the minimum setting: when playing, when stopped, and/or when off.

The Now Playing screen saver is not really a screen saver, so the brightness cannot be reduced when you use this screen saver. A separate pull request (#3) is submitted for that. Although that patch is not a hard requirement for this patch to work.

The patch for the Touch is part of my repo.xml that is included in the official 3rd party extensions list. For the Touch it can be installed when Patch Installer is added. I don't have a radio, so I cannot test it. The patch is available in http://server.vijge.net/static/squeezebox/repo-beta.xml In the [forum thread](https://forums.slimdevices.com/showthread.php?86538-Patch-Reduce-brightness-when-screensaver-is-active&highlight=reducebrightness) on the subject some users reported it to work, whilst others seem to have problems with it.

Translations only include English and Dutch. For all other languages English is used.