### PR TITLE
Bugfix: Manually repairing network may lock up UI on failure

### DIFF
--- a/src/squeezeplay_squeezeos/share/applets/Diagnostics/strings.txt
+++ b/src/squeezeplay_squeezeos/share/applets/Diagnostics/strings.txt
@@ -1730,3 +1730,33 @@ NETWORK_PROBLEM_HELP
 	RU	Неполадки связи Squeezebox с сетью.\nВарианты решений:\n — проверить, устанавливается ли связь с Интернетом с компьютера в домашней сети.\n — перезагрузить устройство, управляющее вашей домашней сетью. Обычно это беспроводной маршрутизатор или широкополосный модем.
 	SV	Squeezebox-enheten har nätverksproblem.\nMöjliga lösningar:\n – Kontrollera att en dator i ditt hemnätverk kan anslutas till Internet.\n – Starta om den enhet som hanterar ditt hemnätverk. Detta är vanligen en trådlös router eller ett bredbandsmodem.
 
+NETWORK_REPAIR_PROBLEM
+	CS	Problém s opravou sítě
+	DA	Problem med at reparere netværk
+	DE	Problem beim Reparieren des Netzwerks
+	EN	Problem repairing network
+	ES	Problema de reparación de la red
+	FI	Ongelma verkon korjaamisessa
+	FR	Problème de réparation du réseau
+	IT	Problema durante la riparazione della rete
+	NL	Probleem met het repareren van netwerk
+	NO	Problem med å reparere nettverket
+	PL	Problem z naprawą sieci
+	RU	Проблема ремонта сети
+	SV	Problem med att reparera nätverket
+
+NETWORK_REPAIR_COMPLETE
+	CS	Oprava sítě dokončena
+	DA	Netværksreparation afsluttet
+	DE	Netzwerkreparatur abgeschlossen
+	EN	Network repair completed
+	ES	Se completó la reparación de la red
+	FI	Verkon korjaus valmis
+	FR	Réparation du réseau terminée
+	IT	Riparazione di rete completata
+	NL	Netwerk reparatie voltooid
+	NO	Nettverksreparasjon fullført
+	PL	Naprawa sieci zakończona
+	RU	Ремонт сети завершен
+	SV	Nätverksreparation slutförd
+

--- a/src/squeezeplay_squeezeos/share/jive/net/Networking.lua
+++ b/src/squeezeplay_squeezeos/share/jive/net/Networking.lua
@@ -2306,6 +2306,12 @@ function repairNetwork(class, ifObj, callback)
 	Task("repairnetwork", ifObj, function()
 		log:info("repairNetwork task started")
 
+		-- Check for valid network interface
+		if ifObj == nil then
+			callback(false, -1)
+			return
+		end
+
 		local active = ifObj:_ifstate()
 
 		callback(true, 100)


### PR DESCRIPTION
This proposed change hardens up the "Repair network" option in the SqueezeOS diagnostics menu, under "Network Health" in the Diagnostics menu.

Forum member P Nelson reported that an attempt to repair his Radio's network caused the Radio's UI to lock up, requiring a forced shutdown to recover matters. I subsequently confirmed the issue myself.

https://forums.slimdevices.com/showthread.php?113479-Announce-Community-Firmware-for-Squeezebox-Radio-Touch-Controller-and-LMS-8&p=1011202&viewfull=1#post1011202

I have located the basic cause - the "Repair Network" option is not simply resilient to failure.

The proposed change explicitly deals with one known cause of failure. Other potential, but unknown, failures are catered for by implementing a "timer backstop" that will free the UI if the "repair" is not completed within 20 seconds. This should be more than enough time.

I have tested the change on a Radio and a Controller, and both appear to work as expected, with no apparent adverse side effects. I do not have a Touch, so I have not been able to check operation there, although I would not anticipate any difference in behaviour.

