### PR TITLE
Fix to prevent "stuck" set up menus when network interfaces not found

### DIFF
--- a/src/squeezeplay_squeezeos/share/applets/Diagnostics/strings.txt
+++ b/src/squeezeplay_squeezeos/share/applets/Diagnostics/strings.txt
@@ -1655,3 +1655,36 @@ NETWORK_REPAIR_COMPLETE
 	RU	Ремонт сети завершен
 	SV	Nätverksreparation slutförd
 
+#
+# Added to support 'No interfaces available' fault scenario
+#
+
+NO_INTERFACE_FOUND_ETH
+	CS	Vyskytl se neočekávaný problém.\n\nNepodařilo se nám najít ethernetový hardware na tomto zařízení, a proto nemáme co ukázat.\n\nTo je vše, co víme.
+	DA	Der er opstået et uventet problem.\n\nVi har ikke været i stand til at finde Ethernet-hardwaren på denne enhed og har derfor intet at vise.\n\nDet er alt, hvad vi ved.
+	DE	Es ist ein unerwartetes Problem aufgetreten.\n\nWir konnten die Ethernet-Hardware auf diesem Gerät nicht finden und können daher nichts anzeigen.\n\nDas ist alles, was wir wissen.
+	EN	An unexpected problem has arisen.\n\nWe have been unable to find the Ethernet hardware on this device and, therefore, have nothing to show.\n\nThat's all we know.
+	ES	Ha surgido un problema inesperado.\n\nNo hemos podido encontrar el hardware Ethernet en este dispositivo y, por lo tanto, no tenemos nada que mostrar.\n\nEso es todo lo que sabemos.
+	FI	Odottamaton ongelma on ilmennyt.\n\nEmme ole löytäneet tämän laitteen Ethernet-laitteistoa, joten meillä ei ole mitään näytettävää.\n\nSe on kaikki, mitä tiedämme.
+	FR	Un problème inattendu est survenu.\n\nNous n'avons pas pu trouver le matériel Ethernet sur cet appareil et, par conséquent, nous n'avons rien à afficher.\n\nC'est tout ce que nous savons.
+	IT	Si è verificato un problema imprevisto.\n\nNon siamo riusciti a trovare l'hardware Ethernet su questo dispositivo e, pertanto, non abbiamo nulla da mostrare.\n\nQuesto è tutto ciò che sappiamo.
+	NL	Er heeft zich een onverwacht probleem voorgedaan.\n\nWe hebben de Ethernet-hardware op dit apparaat niet kunnen vinden en kunnen daarom niets laten zien.\n\nDat is alles wat we weten.
+	NO	Et uventet problem har oppstått.\n\nVi har ikke klart å finne Ethernet-maskinvaren på denne enheten og har derfor ingenting å vise.\n\nDet er alt vi vet.
+	PL	Wystąpił nieoczekiwany problem.\n\nNie udało nam się znaleźć sprzętu Ethernet w tym urządzeniu i dlatego nie mamy nic do pokazania.\n\nTo wszystko, co wiemy.
+	RU	Возникла непредвиденная проблема.\n\nНам не удалось найти оборудование Ethernet на этом устройстве, поэтому нам нечего показать.\n\nЭто все, что нам известно.
+	SV	Ett oväntat problem har uppstått.\n\nVi har inte kunnat hitta Ethernet-hårdvaran på den här enheten och har därför inget att visa.\n\nDet är allt vi vet.
+
+NO_INTERFACE_FOUND_WIFI
+	CS	Vyskytl se neočekávaný problém.\n\nNepodařilo se nám najít bezdrátový hardware na tomto zařízení, a proto nemáme co ukázat.\n\nTo je vše, co víme.
+	DA	Der er opstået et uventet problem.\n\nVi har ikke været i stand til at finde den trådløse hardware på denne enhed og har derfor ikke noget at vise.\n\nDet er alt, hvad vi ved.
+	DE	Es ist ein unerwartetes Problem aufgetreten.\n\nWir konnten die Wireless-Hardware auf diesem Gerät nicht finden und können daher nichts anzeigen.\n\nDas ist alles, was wir wissen.
+	EN	An unexpected problem has arisen.\n\nWe have been unable to find the Wireless hardware on this device and, therefore, have nothing to show.\n\nThat's all we know.
+	ES	Ha surgido un problema inesperado.\n\nNo hemos podido encontrar el hardware inalámbrico en este dispositivo y, por lo tanto, no tenemos nada que mostrar.\n\nEso es todo lo que sabemos.
+	FI	Odottamaton ongelma on ilmennyt.\n\nEmme löytäneet tämän laitteen langatonta laitteistoa, joten meillä ei ole mitään näytettävää.\n\nSe on kaikki, mitä tiedämme.
+	FR	Un problème inattendu est survenu.\n\nNous n'avons pas pu trouver le matériel sans fil sur cet appareil et, par conséquent, nous n'avons rien à afficher.\n\nC'est tout ce que nous savons.
+	IT	Si è verificato un problema imprevisto.\n\nNon siamo riusciti a trovare l'hardware wireless su questo dispositivo e, pertanto, non abbiamo nulla da mostrare.\n\nQuesto è tutto ciò che sappiamo.
+	NL	Er heeft zich een onverwacht probleem voorgedaan.\n\nWe hebben de draadloze hardware op dit apparaat niet kunnen vinden en kunnen daarom niets laten zien.\n\nDat is alles wat we weten.
+	NO	Et uventet problem har oppstått.\n\nVi har ikke klart å finne den trådløse maskinvaren på denne enheten og har derfor ingenting å vise.\n\nDet er alt vi vet.
+	PL	Wystąpił nieoczekiwany problem.\n\nNie udało nam się znaleźć sprzętu bezprzewodowego w tym urządzeniu i dlatego nie mamy nic do pokazania.\n\nTo wszystko, co wiemy.
+	RU	Возникла непредвиденная проблема.\n\nНам не удалось найти беспроводное оборудование на этом устройстве, поэтому нам нечего показать.\n\nЭто все, что нам известно.
+	SV	Ett oväntat problem har uppstått.\n\nVi har inte kunnat hitta den trådlösa hårdvaran på den här enheten och har därför inget att visa.\n\nDet är allt vi vet.

--- a/src/squeezeplay_squeezeos/share/applets/SetupNetworking/SetupNetworkingApplet.lua
+++ b/src/squeezeplay_squeezeos/share/applets/SetupNetworking/SetupNetworkingApplet.lua
@@ -167,71 +167,87 @@ end
 function _connectionType(self)
 	log:debug('_connectionType')
 
-	assert(self.wlanIface or self.ethIface)
+	-- This 'assert' is no longer needed, the case is handled below.
+	-- assert(self.wlanIface or self.ethIface)
 
--- fm+
-	-- Shortcut to use Ethernet immediately if available and link is up
+	-- Shortcut to use Ethernet immediately if available and link is up.
+	-- If link is not up the Task will fall back to wireless.
+	-- Remark: 't_wpaStatus()' should only be accessed in a task.
 	if self.ethIface then
 		Task("halfDuplexBugVerification", self,
 			function()
 				local status = self.ethIface:t_wpaStatus()
 				if status.link then
 					return _halfDuplexBugVerification(self, self.ethIface)
-				else
-					-- Ethernet available but no link - do a wireless scan
+
+				elseif self.wlanIface then
+					-- Ethernet available but no link - do a wireless scan.
+					-- Remark: '_networkScan' would cause this Task to crash
+					-- if 'self.wlanIface' is nil. (Hardware/firmware
+					-- malfunction could trigger this).
 					return _networkScan(self, self.wlanIface)
+
+				else
+					-- Fall back. There is no wireless interface available, so
+					-- we can only use Ethernet. User will be prompted to plug
+					-- in cable if needed.
+					
+					-- Remark: This is likely to arise of there is a Hardware,
+					-- or perhaps firmware, malfunction.
+
+					-- Remark: Baby/Radio hardware versions < 5 could fail
+					-- '_halfDuplexBugVerification'. If so, a menu containing
+					-- the option to connect to wireless will be offered.
+					-- That will just 'bump' because 'self.wlanIface' is nil.
+					-- This Task will not crash.
+
+					log:debug('Wireless interface not found - forcing ethernet connection')
+
+					return _halfDuplexBugVerification(self, self.ethIface)
 				end
 			end
 		):addTask()
-	else
-		-- Only wireless available - do a wireless scan
-		return _networkScan(self, self.wlanIface)
-	end
--- fm-
 
+		return
 
---[[
-	-- short cut if only one interface is available
-	if not self.wlanIface then
-		-- Only ethernet available
-		return _networkScan(self, self.ethIface)
-	elseif not self.ethIface then
-		-- Only wireless available
+	-- Only wireless available - do a wireless scan.
+	elseif self.wlanIface then
+
+		-- Remark: This is the path a Jive/Controller should take, it has no
+		-- Ethernet.
 		return _networkScan(self, self.wlanIface)
+
 	end
 
-	-- ask the user to choose
-	local window = Window("text_list", self:string("NETWORK_CONNECTION_TYPE"), "setup")
+	-- Disaster. Hardware/firmware malfunction - no interfaces available.
+	-- Present a window with an explanatory message and a single 'Continue'
+	-- option which will complete the network setup flow or network settings
+	-- flow.
+
+	-- Remark: Triggered by: Jive/Controller without a Wireless interface,
+	-- or Radio/Touch without both Ethernet and Wireless interfaces.
+
+	log:debug('No network interfaces found, showing bail out menu')
+
+	local window = Window("error", self:string('NETWORK_NO_INTERFACE_FOUND'), 'setuptitle')
 	window:setAllowScreensaver(false)
+	window:setButtonAction("rbutton", nil)
 
-	local connectionMenu = SimpleMenu("menu")
-
-	connectionMenu:addItem({
-		iconStyle = 'wlan',
-		text = (self:string("NETWORK_CONNECTION_TYPE_WIRELESS")),
-		sound = "WINDOWSHOW",
-		callback = function()
-			_networkScan(self, self.wlanIface)
-		end,
-		weight = 1
-	})
-	
-	connectionMenu:addItem({
-		iconStyle = 'wired',
-		text = (self:string("NETWORK_CONNECTION_TYPE_WIRED")),
-		sound = "WINDOWSHOW",
-		callback = function()
-			_networkScan(self, self.ethIface)
-		end,
-		weight = 2
+	local menu = SimpleMenu("menu", {
+		{
+			text = self:string("NETWORK_NO_INTERFACE_CONTINUE"),
+			sound = "WINDOWSHOW",
+			callback = function()
+				self.setupNext()
+			end
+		},
 	})
 
-	window:addWidget(connectionMenu)
+	local helpText = self:string("NETWORK_NO_INTERFACE_HELP_TXT")
+	menu:setHeaderWidget(Textarea("help_text", helpText))
 
-	_helpAction(self, window, "NETWORK_CONNECTION_HELP", "NETWORK_CONNECTION_HELP_BODY", connectionMenu)
-
+	window:addWidget(menu)
 	self:tieAndShowWindow(window)
---]]
 end
 
 

--- a/src/squeezeplay_squeezeos/share/applets/SetupNetworking/SetupNetworkingApplet.lua
+++ b/src/squeezeplay_squeezeos/share/applets/SetupNetworking/SetupNetworkingApplet.lua
@@ -167,8 +167,9 @@ end
 function _connectionType(self)
 	log:debug('_connectionType')
 
-	-- assert(self.wlanIface or self.ethIface)
+	assert(self.wlanIface or self.ethIface)
 
+-- fm+
 	-- Shortcut to use Ethernet immediately if available and link is up
 	if self.ethIface then
 		Task("halfDuplexBugVerification", self,
@@ -176,19 +177,30 @@ function _connectionType(self)
 				local status = self.ethIface:t_wpaStatus()
 				if status.link then
 					return _halfDuplexBugVerification(self, self.ethIface)
-				elseif self.wlanIface then
+				else
 					-- Ethernet available but no link - do a wireless scan
 					return _networkScan(self, self.wlanIface)
 				end
 			end
 		):addTask()
-	elseif self.wlanIface then
-		-- Is wireless available - then do a wireless scan
+	else
+		-- Only wireless available - do a wireless scan
+		return _networkScan(self, self.wlanIface)
+	end
+-- fm-
+
+
+--[[
+	-- short cut if only one interface is available
+	if not self.wlanIface then
+		-- Only ethernet available
+		return _networkScan(self, self.ethIface)
+	elseif not self.ethIface then
+		-- Only wireless available
 		return _networkScan(self, self.wlanIface)
 	end
 
-
-	-- No networking available, ask the user to choose
+	-- ask the user to choose
 	local window = Window("text_list", self:string("NETWORK_CONNECTION_TYPE"), "setup")
 	window:setAllowScreensaver(false)
 
@@ -219,6 +231,7 @@ function _connectionType(self)
 	_helpAction(self, window, "NETWORK_CONNECTION_HELP", "NETWORK_CONNECTION_HELP_BODY", connectionMenu)
 
 	self:tieAndShowWindow(window)
+--]]
 end
 
 

--- a/src/squeezeplay_squeezeos/share/applets/SetupNetworking/strings.txt
+++ b/src/squeezeplay_squeezeos/share/applets/SetupNetworking/strings.txt
@@ -1579,3 +1579,54 @@ NETWORK_ENTER_SSID_HINT
 	RU	Убедитесь, что сеть работает и находится в диапазоне доступа. Если сеть скрыта, необходимо ввести имя сети вручную.
 	SV	Kontrollera att nätverket är i gång och att det är inom räckvidden. Om nätverket är dolt måste du ange namnet manuellt.
 
+
+#
+# Added to support 'No interfaces available' fault scenario
+#
+
+NETWORK_NO_INTERFACE_FOUND
+	CS	Žádný síťový hardware
+	DA	Ingen netværkshardware
+	DE	Keine Netzwerkhardware
+	EN	No network hardware
+	ES	Sin hardware de red
+	FI	Ei verkkolaitteistoa
+	FR	Pas de matériel réseau
+	IT	Nessun hardware di rete
+	NL	Geen netwerkhardware
+	NO	Ingen nettverksmaskinvare
+	PL	Brak sprzętu sieciowego
+	RU	Нет сетевого оборудования
+	SV	Ingen nätverkshårdvara
+
+NETWORK_NO_INTERFACE_CONTINUE
+	CS	Pokračovat
+	DA	Fortsætte
+	DE	Weitermachen
+	EN	Continue
+	ES	Continuar
+	FI	Jatkaa
+	FR	Continuer
+	IT	Continuare
+	NL	Doorgaan
+	NO	Fortsette
+	PL	Kontynuować
+	RU	Продолжать
+	SV	Fortsätta
+
+NETWORK_NO_INTERFACE_HELP_TXT
+	CS	Vyskytl se neočekávaný problém.\nNepodařilo se nám najít síťový hardware na tomto zařízení, a proto nemůžeme vybrat síť, ke které se připojíme.
+	DA	Der er opstået et uventet problem.\nVi har ikke været i stand til at finde netværkshardwaren på denne enhed, og vi kan derfor ikke vælge et netværk at oprette forbindelse til.
+	DE	Es ist ein unerwartetes Problem aufgetreten.\nWir konnten die Netzwerkhardware auf diesem Gerät nicht finden und können daher kein Netzwerk für die Verbindung auswählen.
+	EN	An unexpected problem has arisen.\nWe have been unable to find the network hardware on this device, and, therefore, we cannot choose a network to connect to.
+	ES	Ha surgido un problema inesperado.\nNo hemos podido encontrar el hardware de red en este dispositivo y, por lo tanto, no podemos elegir una red para conectarnos.
+	FI	On ilmennyt odottamaton ongelma.\nEmme löytäneet tämän laitteen verkkolaitteistoa, emmekä siksi voi valita verkkoa, johon muodostaa yhteyden.
+	FR	Un problème inattendu est survenu.\nNous n'avons pas réussi à trouver le matériel réseau sur cet appareil et, par conséquent, nous ne pouvons pas choisir un réseau auquel nous connecter.
+	IT	Si è verificato un problema imprevisto.\nNon siamo riusciti a trovare l'hardware di rete su questo dispositivo e, pertanto, non possiamo scegliere una rete a cui connetterci.
+	NL	Er heeft zich een onverwacht probleem voorgedaan.\nWe hebben de netwerkhardware op dit apparaat niet kunnen vinden en kunnen daarom geen netwerk kiezen om verbinding mee te maken.
+	NO	Et uventet problem har oppstått.\nVi har ikke klart å finne nettverksmaskinvaren på denne enheten, og derfor kan vi ikke velge et nettverk å koble til.
+	PL	Wystąpił nieoczekiwany problem.\nNie udało nam się znaleźć sprzętu sieciowego na tym urządzeniu i dlatego nie możemy wybrać sieci, z którą chcemy się połączyć.
+	RU	Возникла непредвиденная проблема.\nНам не удалось найти сетевое оборудование на этом устройстве, поэтому мы не можем выбрать сеть для подключения.
+	SV	Ett oväntat problem har uppstått.\nVi har inte kunnat hitta nätverkshårdvaran på den här enheten, och därför kan vi inte välja ett nätverk att ansluta till.
+
+


### PR DESCRIPTION
This proposed change replaces commit 7b5c3b4, _Fix for the Touch getting stuck on Choose A Language_, and adds a supplementary change to the Ethernet/Wireless Diagnostics applet that makes it more obvious that a problem exists.

- **Network setup: Be more resilient if network interfaces are not present**

This replaces the previous commit 7b5c3b4.   There is a problem with that commit:

The code that generates and executes the “fall back” menu will **always** be executed if an Ethernet interface exists. This is not obviously apparent from the UI, but can be easily seen if logging traces are inserted. The reason is that, in this case, the network setup code is executed in a background Task. So we proceed to the “fall back” menu immediately after launching the Task, regardless of whether the Task succeeds or not.

I am not sure if this behaviour is harmful, I don't know how the underlying UI system deals with it. But I think it would be prudent to avoid it as we may end up with "stranded" Windows/Menus. 

This proposed change introduces the “fall back” into the Task itself. This consists of attempting an Ethernet connection despite the link being down. The user will be prompted  to insert an Ethernet cable, which I think is probably desirable behaviour, as there is no other realistic option.

In the absence of both an Ethernet and Wireless interface, a “fall back” menu is displayed advising the user that a problem exists, and offering a “Continue” option that terminates the set up procedure in a controlled way. At this point it really is game over.

- **Network diagnostics: Highlight problem if network interface not present**

This change amends the diagnostic screen to present a brief explanatory text which explicitly highlights that a problem exists. At present the diagnostics screen would just show an unpopulated list of status items if the interface does not exist. That may not immediately catch all users’ attention. Both Ethernet and Wireless diagnostic screens have been modified.

- **Other matters**

I think we might expect this problem to become more common as the hardware ages, so it is worth paying attention to.

I have tested the changes on both a Radio and a Controller. I have attempted to exercise all execution paths possible by “forcing” the fault conditions to exist, all seems to function as intended. But an independent review may bring up something I have missed.

I have put in language translations for some languages. Missing are: CS, DA, FI, NO, PL, RU, SV. If I can fill in some gaps over the next few days, I shall.

**EDIT:** Now done, all languages present in revised commits.
