### PR TITLE
Bug fix: Suppress annoying error messages from jive.ui.Textarea & jive…

### DIFF
--- a/src/squeezeplay/src/ui/jive_textarea.c
+++ b/src/squeezeplay/src/ui/jive_textarea.c
@@ -467,17 +467,22 @@ int jiveL_textarea_draw(lua_State *L) {
 			break;
 		}
 
-		/* shadow text */
-		if (peer->is_sh) {
-			tsrf = jive_font_draw_text(peer->font, peer->sh, &text[line]);
-			jive_surface_blit(tsrf, srf, x + 1, y + 1);
+		/* to suppress 'get_image_surface - no SDL surface available' error we
+		   only draw if there's something to draw */
+		if (text[line] != '\0') {
+
+			/* shadow text */
+			if (peer->is_sh) {
+				tsrf = jive_font_draw_text(peer->font, peer->sh, &text[line]);
+				jive_surface_blit(tsrf, srf, x + 1, y + 1);
+				jive_surface_free(tsrf);
+			}
+
+			/* foreground text */
+			tsrf = jive_font_draw_text(peer->font, peer->fg, &text[line]);
+			jive_surface_blit(tsrf, srf, x, y);
 			jive_surface_free(tsrf);
 		}
-
-		/* foreground text */
-		tsrf = jive_font_draw_text(peer->font, peer->fg, &text[line]);
-		jive_surface_blit(tsrf, srf, x, y);
-		jive_surface_free(tsrf);
 
 		text[next] = c;
 		text[(next - 1)] = b;

--- a/src/squeezeplay/src/ui/jive_textinput.c
+++ b/src/squeezeplay/src/ui/jive_textinput.c
@@ -309,14 +309,20 @@ int jiveL_textinput_draw(lua_State *L) {
 	  
 		if (peer->is_sh) {
 			/* pre-cursor */
-			tsrf = jive_font_ndraw_text(peer->font, peer->sh, text, cursor - cursor_width);
-			jive_surface_blit(tsrf, srf, text_x + 1, text_y + offset_y + 1);
-			jive_surface_free(tsrf);
+			/* to suppress 'get_image_surface - no SDL surface available' error we only draw if there's something to draw */
+			if (len_1 > 0) {
+				tsrf = jive_font_ndraw_text(peer->font, peer->sh, text, cursor - cursor_width);
+				jive_surface_blit(tsrf, srf, text_x + 1, text_y + offset_y + 1);
+				jive_surface_free(tsrf);
+			}
 
 			/* cursor */
-			tsrf = jive_font_ndraw_text(peer->cursor_font, peer->sh, text + cursor - cursor_width, cursor_width);
-			jive_surface_blit(tsrf, srf, cursor_x + (cursor_w - len_2) / 2 + 1, text_y + offset_cursor_y + 1);
-			jive_surface_free(tsrf);
+			/* something to draw ? */
+			if (len_2 > 0) {
+				tsrf = jive_font_ndraw_text(peer->cursor_font, peer->sh, text + cursor - cursor_width, cursor_width);
+				jive_surface_blit(tsrf, srf, cursor_x + (cursor_w - len_2) / 2 + 1, text_y + offset_cursor_y + 1);
+				jive_surface_free(tsrf);
+			}
 
 			/* post-cursor */
 			if (cursor < text_len) {
@@ -327,14 +333,20 @@ int jiveL_textinput_draw(lua_State *L) {
 		}
 
 		/* pre-cursor */
-		tsrf = jive_font_ndraw_text(peer->font, peer->fg, text, cursor - cursor_width);
-		jive_surface_blit(tsrf, srf, text_x, text_y + offset_y);
-		jive_surface_free(tsrf);
+		/* something to draw ? */
+		if (len_1 > 0) {
+			tsrf = jive_font_ndraw_text(peer->font, peer->fg, text, cursor - cursor_width);
+			jive_surface_blit(tsrf, srf, text_x, text_y + offset_y);
+			jive_surface_free(tsrf);
+		}
 
 		/* cursor */
-		tsrf = jive_font_ndraw_text(peer->cursor_font, peer->cursor_color, text + cursor - cursor_width, cursor_width);
-		jive_surface_blit(tsrf, srf, cursor_x + (cursor_w - len_2) / 2, text_y + offset_cursor_y);
-		jive_surface_free(tsrf);
+		/* something to draw ? */
+		if (len_2 > 0) {
+			tsrf = jive_font_ndraw_text(peer->cursor_font, peer->cursor_color, text + cursor - cursor_width, cursor_width);
+			jive_surface_blit(tsrf, srf, cursor_x + (cursor_w - len_2) / 2, text_y + offset_cursor_y);
+			jive_surface_free(tsrf);
+		}
 
 		/* post-cursor */
 		if (cursor < text_len) {


### PR DESCRIPTION
This proposed change quietens the regular error messages ('_get_image_surface - no SDL surface available_') that are logged by `jive.ui.Textarea` & `jive.ui.Textinput` whenever a zero length string turns up in the text to be written. For example, user help text, etc, will often have an empty line to give effect to spacing. ("`\n\n`" stanzas in test strings).

They can really get in the way when one is looking out for specific log entries.

To demonstrate:

Ensure that logging for `squeezeplay.ui `and `squeezeplay.ui.draw` is set to 'Error'. Run a 'tail' on the log.

- Enter the Image Viewer applet, and choose "Image Viewer Settings/Source specific settings". This presents a `Textinput` box. Move the cursor point around a bit, and error messages will ensue.

- Enter the Network Test applet. A test will start, but call up Help. (Press big wheel on Radio). The help screen, which is displayed in a `Textarea`, has a number of empty lines, which, again, will trigger the error message.

This fix also applies to the regular Squeezeplay application.

I don't see this as a particularly vital fix, but those of us who view the logs regularly might appreciate it. 😄 
