### PR TITLE
Retrieve default TimeZone from an LMS server

### DIFF
--- a/src/squeezeplay_squeezeos/share/applets/SetupTZ/SetupTZMeta.lua
+++ b/src/squeezeplay_squeezeos/share/applets/SetupTZ/SetupTZMeta.lua
@@ -52,7 +52,7 @@ function notify_serverConnected(meta, server)
 					-- no action - this is RequestHttp's final 'nil' data callback
 				end
 			end,
-			'GET', '/tz'
+			'GET', '/time/tz'
 		)
 		socket:fetch(req)
 	else

--- a/src/squeezeplay_squeezeos/share/applets/SetupTZ/SetupTZMeta.lua
+++ b/src/squeezeplay_squeezeos/share/applets/SetupTZ/SetupTZMeta.lua
@@ -27,23 +27,32 @@ function registerApplet(meta)
 	end
 end
 
-function notify_serverConnected(meta)
+function notify_serverConnected(meta, server)
 	-- On server connect, if the timezone still hasn't
-	-- been set, set it from SN's guess over http
+	-- been set, set it from LMS's guess over http
 	-- and unsubscribe if this succeeds
+
+	-- There is a small possibility of a race condition if more than one LMS
+	-- server becomes connected. But that won't cause harm.
 	if not squeezeos.getTimezone() then
-		local socket = SocketHttp(jnt, jnt:getSNHostname(), 80, "tzguess")
+		local socket = SocketHttp(jnt, server.ip, server.port, "tzguess")
 		local req = RequestHttp(
-			function(data) if data then
-				log:debug("Got http data for TZ >>" .. data .. "<<")
-				local success,err = squeezeos.setTimezone(data)
-				if success then
-					jnt:unsubscribe(meta)
+			function(data, err)
+				if err then
+					log:warn("Bad response from server {", server.name, "} Error:", err)
+				elseif data then
+					log:info("Got TimeZone from server {", server.name, "} : {", data, "}")
+					local success, err = squeezeos.setTimezone(data)
+					if success then
+						jnt:unsubscribe(meta)
+					else
+						log:warn("setTimezone() failed: ", err)
+					end
 				else
-					log:warn("setTimezone() failed: ", err)
+					-- no action - this is RequestHttp's final 'nil' data callback
 				end
-			end end,
-			'GET', '/public/tz'
+			end,
+			'GET', '/tz'
 		)
 		socket:fetch(req)
 	else

--- a/src/squeezeplay_squeezeos/src/squeezeos.c
+++ b/src/squeezeplay_squeezeos/src/squeezeos.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 static int squeezeos_reboot(lua_State *L)
 {
@@ -179,6 +180,9 @@ static int squeezeos_set_timezone(lua_State *L)
 {
 	const char* tz = lua_tostring(L, 1);
 	char* tzfn = malloc(21 + strlen(tz));
+	char* tzfn_canon;
+	char* tzptr;
+	struct stat statbuf;
 
 	if(!tzfn) {
 		lua_pushnil(L);
@@ -187,6 +191,37 @@ static int squeezeos_set_timezone(lua_State *L)
 	}
 	strcpy(tzfn, "/usr/share/zoneinfo/");
 	strcat(tzfn, tz);
+
+	/* Carry out some sanity checks on the provided timezone. 'tzfn' must
+	   resolve to a target tzdata file in the zoneinfo hierarchy. */
+
+	/* Resolve symlinks, etc.; fail if the target does not exist */
+	tzfn_canon = canonicalize_file_name(tzfn);
+	if(!tzfn_canon) {
+		free(tzfn);
+		lua_pushnil(L);
+		lua_pushstring(L, "Cannot locate tz data file");
+		return 2;
+	}
+	/* Require the target to fall within the zoneinfo hierarchy */
+	tzptr = strstr(tzfn_canon, "/usr/share/zoneinfo/");
+	if (tzptr != tzfn_canon) {
+		free(tzfn);
+		free(tzfn_canon);
+		lua_pushnil(L);
+		lua_pushstring(L, "tz data file is not in /usr/share/zoneinfo");
+		return 2;
+	}
+	/* Require the target to be a regular file */
+	if (stat(tzfn_canon, &statbuf) || !S_ISREG(statbuf.st_mode)) {
+		free(tzfn);
+		free(tzfn_canon);
+		lua_pushnil(L);
+		lua_pushstring(L, "tz data does not point to a file");
+		return 2;
+	}
+	/* Sanity checks passed. Proceed to create '/etc/localtime' link */
+	free(tzfn_canon);
 
 	if(unlink("/etc/localtime") && errno != ENOENT) {
 		free(tzfn);


### PR DESCRIPTION
This proposed change amends the `SetupTZ `applet so that it now obtains a default TimeZone from an LMS server if the device's TimeZone has not been initialized. This would arise following a “factory reset” or on first set up. The service was formerly provided by _MySqueezeBox.com_, but that is no longer available.

A companion change to the Community Firmware plugin has been prepared in support. The plugin implements the service by providing a Slim Query named `getlmstimezone`, which returns an Olson formatted TimeZone string in the result field `timezone`. It returns the empty string on failure.

The plugin obtains a best guess of the LMS server’s local TimeZone by making an API call to `https://stats.lms-community.org/api/time`, which has been recently implemented by @mherger.

This PR refers: https://github.com/ralph-irving/plugin-CommunityFirmware/pull/8

After retrieving the result of the Query, a number of validation checks are carried out before attempting to set the TimeZone:

- Verify that the TimeZone response is a non empty string.
- Verify that the provided TimeZone falls within the '/usr/share/zoneinfo/' hierarchy, and doesn't contain any path traversal (`/..`) or similarly unwanted elements.
- Check that it is not one of the reserved `Factory` or `Etc/Unknown` TimeZones.
- Check that there exists a readable TimeZone file.

Should  the server does not implement the `getlmstimezone` request[1], then SqueezeOS will simply not receive a useful response, and no action will be taken. A ‘timeout’ log trace will be made after 10 seconds, although few users would see this.

The proposed change has been tested locally on Squeezebox Radio, and appears to operate as expected.

I would appreciate receiving any feedback on the proposal.

[1] For example, if the Community Firmware plugin is not installed.
