### PR TITLE
Update SocketHttp.lua

### DIFF
--- a/src/squeezeplay/share/jive/net/SocketHttp.lua
+++ b/src/squeezeplay/share/jive/net/SocketHttp.lua
@@ -744,7 +744,7 @@ sinkt["jive-by-chunk"] = function(request)
 
 		if not chunk or src_err == "done" then
 			log:debug("SocketHttp.jive-by-chunk.sink: done")
-			request:t_setResponseBody(nil)
+--			request:t_setResponseBody(nil)
 			return nil
 		end
 	


### PR DESCRIPTION
This call t_setResponseBody with nil is treated as reporting an error. But the code is executed when the request is completed.

I don't think there is any need to call. t_setResponseBody at all.

Current code prevents PatchInstaller.lua from working when the patch URL is redirected.  When the 301 header is read, this code causes RequestHttp to attempt to report an error.  Since there is no "code" in nil, line 406 in RequestHttp.lua attempts to concatenate a string with a boolean (false) - an error.

RequestHttp then closes the sink, which should be left for use by the redirect.

I think this is the correct place to fix the problem.  A workaround can be added in RequestHttp.lua to handle this case, but there is no reason to call t_setResponseBody with nil in the first place.