### PR TITLE
Changes to NowPlayingApplet.lua to work correctly with CustomClockApplet.lua

### DIFF
--- a/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
+++ b/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
@@ -647,7 +647,9 @@ function addNowPlayingItem(self)
 		sound = 'WINDOWSHOW',
 		weight = 1,
 		callback = function(event, menuItem)
-			self:goNowPlaying(Window.transitionPushLeft)
+-- Lookup current Now Playing service to work with Custom Clock	
+--			self:goNowPlaying(Window.transitionPushLeft)
+			appletManager:callService("goNowPlaying",Window.transitionPushLeft)	
 			end
 	})
 end
@@ -1778,8 +1780,9 @@ function openScreensaver(self)
 	appletManager:callService("deactivateScreensaver") -- not needed currently, but is defensive if other cleanup gets added to deactivateScreensaver
 	appletManager:callService("restartScreenSaverTimer")
 
-	self:showNowPlaying()
-
+-- Lookup current Now Playing service to work with Custom Clock	
+--	self:showNowPlaying()
+	appletManager:callService("goNowPlaying")
 	return false
 end
 

--- a/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
+++ b/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
@@ -633,14 +633,14 @@ end
 
 
 function removeNowPlayingItem(self)
-	jiveMain:removeItemById('appletNowPlaying')
+	jiveMain:removeItemById('appletNowPlayingv2')
 	self.nowPlayingItem = false
 end
 
 
 function addNowPlayingItem(self)
 	jiveMain:addItem({
-		id = 'appletNowPlaying',
+		id = 'appletNowPlayingv2',
 		iconStyle = 'hm_appletNowPlaying',
 		node = 'home',
 		text = self:string('SCREENSAVER_NOWPLAYING'),
@@ -1939,7 +1939,7 @@ end
 
 function freeAndClear(self)
 	self.player = false
-	jiveMain:removeItemById('appletNowPlaying')
+	jiveMain:removeItemById('appletNowPlayingv2')
 	self:free()
 
 end


### PR DESCRIPTION
There are small problems " in NowPlayingApplet.lua that make behavior incorrect when using a Custom Clock.   There is also a problem created by CustomClockApplet.lua, but that can be fixed within NowPlayingApplet.lua.  This latter problem has very minimal impact, so can likely be ignored in hopes that it might be directly fixed in CustomClockApplet.

The changes are simple, but describing the problems requires some detail!

To see the problems, start with this setup:
1. use Settings/Screen/Screensavers/Custom Clock Settings/Replace Now Playing to pick any Custom Clock setting
2. use Settings/Screen/Screensavers/When Playing to select Now Playing 

Error #1:
Tune in any source.  The selected Custom Now Playing screen should display.    After 30-60 seconds, the original/default Now Playing screen will replace this screen as a screensaver.  I believe that it **"should"** show the Now Playing screen chosen by the use.  Note that pressing "back" will change the display from the default Now Playing screen (screensaver) to the custom NP screen.  An additional "back" is required to reach the home menu.

Now change the setup to reset the Now Playing choice
1. use Settings/Screen/Screensavers/Custom Clock Settings/Replace Now Playing to pick Standard (No Replacement)

Error #2: 
Tune in any source.  The original/default Now Playing screen will appear.   Repeatedly press the "home" button and the screen will toggle between the home menu and the Now Playing screen, as expected.    With the home menu, select the Now Playing item.   The previously chosen Custom Clock Now Playing screen will display.   The **menu was not changed** to use the default NP.   Wait the 30-60 seconds for the screensaver -- it will display the default, and again 2 presses of "back" are required to go to the home menu.

Note that if you tune to something the correct, default NP will display and will continue to be displayed after the screensaer delay.  In this case one press of "back" will return to the home menu.

Error #3:
In order to get a Custom Clock to appear as a screensaver, I believe one has to be set as a Config and then selected for the When Playing screensaver.  If you use the same Custom Clock to Replace Now Playing and as the When Playing screensaver, then tune something (shows your Custom Clock), wait for screen saver (still displays Custom Clock), but 2 presses of "back" are required to get to the home menu.   Logically it **should** require only one press, but the two windows are not "the same" to the system.

To fix Error #1 and Error #3:  In function openScreensaver, replace one line:
- OLD: self:showNowPlaying()
- NEW: appletManager:callService("goNowPlaying") 

WIth this change any request to use the current Now Playing screen as a screensaver will look it up with callRequest.  It is no longer necessary to use the Config to set the screensaver for When Playing. This also means that when the screensaver displays the same screen as Now Playing, only one press of "back" is required to return to the home menu.

To fix Error #2:   FIrst, Error #2 is probably not a big problem.  If the first change made, this only occurs between the time a user changes from a Custom Clock NP back to Standard.  The Custom Clock NP continues to display from the home menu because CustomClockApplet changes the menu when installing.   If the user reboots after making the change, the system will operate "correctly".     

Two changes are needed to completely eliminate Error #2 in all conditions:
1. in function addNowPlaying, within the callback function
- OLD:  self:goNowPlaying(Window.transitionPushLeft)
- NEW: appletManager:callService("goNowPlaying",Window.transitionPushLeft)

2. Change the id for the home menu Now Playing entry from appletNowPlaying to appletNowPlayingv2 (or anything of your choice).    The id appears in 3 places.

Fixing Error #2 is probably a very low priority.  Since it is most likely that users rarely change their Now Playing choice, it may not be necessary to make the Now Playing item in the home menu work reliably immediately after.   It will work correctly after a reboot.    Eventually CustomClockApplet can be modified to not change the menu entry.
 
