### PR TITLE
Update NowPlayingApplet.lua

### DIFF
--- a/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
+++ b/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
@@ -1778,7 +1778,8 @@ function openScreensaver(self)
 	appletManager:callService("deactivateScreensaver") -- not needed currently, but is defensive if other cleanup gets added to deactivateScreensaver
 	appletManager:callService("restartScreenSaverTimer")
 
-	self:showNowPlaying()
+	-- Display the currently registered Now Playing screen
+ 	appletManager:callService("goNowPlaying")
 
 	return false
 end


### PR DESCRIPTION
When using "Now Playing" as a screen saver, use the most recently registered Now Playing format, not the one hard coded in this file.