### PR TITLE
UI: performance optimizations and stability improvements for Squeezebox Radio

### DIFF
--- a/src/Makefile.squeezeos
+++ b/src/Makefile.squeezeos
@@ -7,7 +7,7 @@ TOPDIR = $(dir ${TOPSRCDIR})
 export BUILDDIR=$(TOPDIR)build
 export PREFIX=${BUILDDIR}/usr
 
-export CFLAGS=-I${PREFIX}/include -I${SRCDIR}/squeezeplay/src/ui -Os
+export CFLAGS=-I${PREFIX}/include -I${SRCDIR}/squeezeplay/src/ui -O2
 export LDFLAGS=-L${PREFIX}/lib
 
 TARGET=arm-926ejs-linux-gnueabi

--- a/src/Makefile.squeezeos
+++ b/src/Makefile.squeezeos
@@ -7,8 +7,8 @@ TOPDIR = $(dir ${TOPSRCDIR})
 export BUILDDIR=$(TOPDIR)build
 export PREFIX=${BUILDDIR}/usr
 
-export CFLAGS=-I${PREFIX}/include -I${SRCDIR}/squeezeplay/src/ui -O2
-export LDFLAGS=-L${PREFIX}/lib
+export CFLAGS=-I${PREFIX}/include -I${SRCDIR}/squeezeplay/src/ui -Os -ffunction-sections -fdata-sections
+export LDFLAGS=-L${PREFIX}/lib -Wl,--gc-sections
 
 TARGET=arm-926ejs-linux-gnueabi
 

--- a/src/squeezeplay/share/applets/SlimBrowser/SlimBrowserApplet.lua
+++ b/src/squeezeplay/share/applets/SlimBrowser/SlimBrowserApplet.lua
@@ -479,6 +479,8 @@ local function _artworkItem(step, item, group, menuAccel)
 	local iconId = item["icon-id"] or item["icon"]
 
 	if iconId then
+		-- Clear cached state since we're setting real artwork
+		group._iconNoArtwork = nil
 		if menuAccel and not _server:artworkThumbCached(iconId, iconSize) then
 			-- Don't load artwork while accelerated
 			_server:cancelArtwork(icon)
@@ -487,6 +489,8 @@ local function _artworkItem(step, item, group, menuAccel)
 			_server:fetchArtwork(iconId, icon, iconSize)
 		end
 	elseif item["trackType"] == 'radio' and item["params"] and item["params"]["track_id"] then
+		-- Clear cached state since we're setting real artwork
+		group._iconNoArtwork = nil
 		if menuAccel and not _server:artworkThumbCached(item["params"]["track_id"], iconSize) then
 			-- Don't load artwork while accelerated
 			_server:cancelArtwork(icon)
@@ -644,12 +648,14 @@ local function _decoratedLabel(group, labelStyle, item, step, menuAccel)
 
 		group:setWidgetValue("text", item.text)
 
-		if showIcons then
+	if showIcons then
 			--set "no artwork" unless it has already been set (avoids high cpu looping)
-			local iconWidget = group:getWidget('icon')
-			if iconWidget then
-				if group:getWidget('icon'):getStyle() ~= 'icon_no_artwork' then
+			-- Cache state on group to avoid repeated getStyle() string comparisons
+			if not group._iconNoArtwork then
+				local iconWidget = group:getWidget('icon')
+				if iconWidget then
 					group:setWidget('icon', Icon('icon_no_artwork'))
+					group._iconNoArtwork = true
 				end
 			end
 		end

--- a/src/squeezeplay/share/jive/ui/Flick.lua
+++ b/src/squeezeplay/share/jive/ui/Flick.lua
@@ -126,6 +126,9 @@ function stopFlick(self, byFinger)
 end
 
 
+-- Maximum number of points to track for flick velocity calculation
+local FLICK_MAX_POINTS = 20
+
 function updateFlickData(self, mouseEvent)
 	local x, y = mouseEvent:getMouse()
 	local ticks = mouseEvent:getTicks()
@@ -136,53 +139,92 @@ function updateFlickData(self, mouseEvent)
 	end
 
 	--hack until reason for false "far out of range" ticks is happening
-
-	if #self.flickData.points >=1 then
-		local previousTicks = self.flickData.points[#self.flickData.points].ticks
-		if math.abs(ticks - previousTicks ) > 10000 then
-			log:error("Erroneous tick value occurred, ignoring : ", ticks, "  after previuos tick value of: ", previousTicks)
+	local fd = self.flickData
+	if fd.count >= 1 then
+		-- Get the most recent point using circular buffer index
+		local prevIdx = ((fd.nextIdx - 2) % FLICK_MAX_POINTS) + 1
+		local previousTicks = fd.points[prevIdx] and fd.points[prevIdx].ticks or 0
+		if math.abs(ticks - previousTicks) > 10000 then
+			log:error("Erroneous tick value occurred, ignoring : ", ticks, "  after previous tick value of: ", previousTicks)
 			return
 		end
 	end
 
-	--use last flick data collection time as initital scroll time to avoid jerky delay when afterscroll starts 
+	--use last flick data collection time as initial scroll time to avoid jerky delay when afterscroll starts
 	self.flickInitialScrollT = Framework:getTicks()
 
-	table.insert(self.flickData.points, {y = y, ticks = ticks})
-
-	--remove any more than 20 points
-	if #self.flickData.points >= 20 then
-		--only keep last 20 values (number was come up by trial and error, flick and quick stopping, quick flicks, multi-speed flicks)
-		-- I found that having this number lower (less averging) made the afterscroll "jump"
-		-- also only collect events that occurred in the last 100ms
-		table.remove(self.flickData.points, 1)
-	end
-
+	-- Use circular buffer: overwrite oldest entry instead of shifting array
+	local idx = fd.nextIdx
+	fd.points[idx] = {y = y, ticks = ticks}
+	fd.nextIdx = (idx % FLICK_MAX_POINTS) + 1
+	fd.count = math.min(fd.count + 1, FLICK_MAX_POINTS)
 end
 
 function resetFlickData(self)
 	self.flickData.points = {}
+	self.flickData.nextIdx = 1
+	self.flickData.count = 0
+end
+
+-- Helper: get the oldest point in the circular buffer
+local function _getOldestPoint(fd)
+	if fd.count == 0 then return nil end
+	if fd.count < FLICK_MAX_POINTS then
+		return fd.points[1]
+	end
+	return fd.points[fd.nextIdx]  -- nextIdx points to the oldest entry when full
+end
+
+-- Helper: get the newest point in the circular buffer
+local function _getNewestPoint(fd)
+	if fd.count == 0 then return nil end
+	local idx = ((fd.nextIdx - 2) % FLICK_MAX_POINTS) + 1
+	return fd.points[idx]
+end
+
+-- Helper: get point at offset from oldest (0 = oldest, count-1 = newest)
+local function _getPointAt(fd, offset)
+	if offset < 0 or offset >= fd.count then return nil end
+	if fd.count < FLICK_MAX_POINTS then
+		return fd.points[offset + 1]
+	end
+	local idx = ((fd.nextIdx + offset - 1) % FLICK_MAX_POINTS) + 1
+	return fd.points[idx]
 end
 
 function getFlickSpeed(self, itemHeight, mouseUpT)
-	--remove stale points
-	if #self.flickData.points > 1 then
-		local staleRemoved = false
-		repeat
-			if self.flickData.points[#self.flickData.points].ticks - self.flickData.points[1].ticks > FLICK_STALE_TIME then
-				table.remove(self.flickData.points, 1)
-			else
-				staleRemoved = true
-			end
-		until staleRemoved
-	end
+	local fd = self.flickData
 
-	if not self.flickData.points or #self.flickData.points < 2 then
+	if fd.count < 2 then
 		return nil
 	end
 
+	-- Remove stale points by adjusting count (no table operations needed)
+	local newest = _getNewestPoint(fd)
+	while fd.count > 1 do
+		local oldest = _getOldestPoint(fd)
+		if newest.ticks - oldest.ticks > FLICK_STALE_TIME then
+			-- "Remove" oldest by advancing the start pointer
+			if fd.count < FLICK_MAX_POINTS then
+				-- Shift the start for partial buffers
+				table.remove(fd.points, 1)
+			else
+				fd.nextIdx = (fd.nextIdx % FLICK_MAX_POINTS) + 1
+			end
+			fd.count = fd.count - 1
+		else
+			break
+		end
+	end
+
+	if fd.count < 2 then
+		return nil
+	end
+
+	newest = _getNewestPoint(fd)
+
 	if mouseUpT then
-		local delayUntilUp = mouseUpT - self.flickData.points[#self.flickData.points].ticks
+		local delayUntilUp = mouseUpT - newest.ticks
 		if delayUntilUp > 25 then
 			-- a long delay since last point is one indication of a finger stop since lower level duplicate suppression may be in effect
 			return nil
@@ -192,25 +234,24 @@ function getFlickSpeed(self, itemHeight, mouseUpT)
 	--finger stop checking
 	-- finger may have stopped after a drag, but the averaging might make it appear that a flick occurred
 	local recentPoints = 5
-	if #self.flickData.points > recentPoints then
-		local recentIndex = 1 + #self.flickData.points - recentPoints
-		local recentDistance = self.flickData.points[#self.flickData.points].y - self.flickData.points[recentIndex].y
+	if fd.count > recentPoints then
+		local recentPoint = _getPointAt(fd, fd.count - recentPoints)
+		local recentDistance = newest.y - recentPoint.y
 
 		if math.abs(recentDistance) <= FLICK_RECENT_THRESHOLD_DISTANCE then
 			log:debug("Returning nil, didn't surpase 'recent' threshold distance: ", recentDistance)
 			return nil
 		end
-
 	end
 
-	local distance = self.flickData.points[#self.flickData.points].y - self.flickData.points[1].y
-	local time = self.flickData.points[#self.flickData.points].ticks - self.flickData.points[1].ticks
+	local oldest = _getOldestPoint(fd)
+	local distance = newest.y - oldest.y
+	local time = newest.ticks - oldest.ticks
 
 	--speed = pixels/ms
 	local speed = distance/time
 
-
-	log:debug("Flick info: speed: ", speed, "  distance: ", distance, "  time: ", time )
+	log:debug("Flick info: speed: ", speed, "  distance: ", distance, "  time: ", time)
 
 	local direction = speed >= 0 and -1 or 1
 	return math.abs(speed), direction
@@ -334,7 +375,8 @@ function __init(self, parent)
 	obj.flickData = {}
 	obj.flickData.points = {}
 
-	obj.flickTimer = Timer(25,
+	-- Timer interval: 33ms = ~30fps (optimized for low-power devices like Squeezebox Radio)
+	obj.flickTimer = Timer(33,
 			       function()
 			                obj:flick()
 			       end)

--- a/src/squeezeplay/share/jive/ui/Menu.lua
+++ b/src/squeezeplay/share/jive/ui/Menu.lua
@@ -719,48 +719,64 @@ local function _eventHandler(self, event)
 
 					if chiralValue then
 						if self.mouseState ~= MOUSE_CHIRAL then
-							--clear old chiral values
+							--clear old chiral values and initialize circular buffer
 							self.lastChirals = {}
-
+							self.chiralNextIdx = 1
+							self.chiralCount = 0
+							-- Running totals for efficient averaging
+							self.chiralShortTotal = 0
+							self.chiralShortCount = 0
+							self.chiralLongTotal = 0
+							self.chiralLongCount = 0
 						else
-							--did direction change, if clear old values
-							local lastChiral = self.lastChirals[#self.lastChirals].value
-							if lastChiral * chiralValue < 1 then
-								--direction shift
-								self.lastChirals = {}
+							--did direction change, if so clear old values
+							if self.chiralCount > 0 then
+								local prevIdx = ((self.chiralNextIdx - 2) % 50) + 1
+								local lastChiral = self.lastChirals[prevIdx]
+								if lastChiral and lastChiral.value * chiralValue < 1 then
+									--direction shift - reset buffer
+									self.lastChirals = {}
+									self.chiralNextIdx = 1
+									self.chiralCount = 0
+									self.chiralShortTotal = 0
+									self.chiralShortCount = 0
+									self.chiralLongTotal = 0
+									self.chiralLongCount = 0
+								end
 							end
 						end
 
 						self.mouseState = MOUSE_CHIRAL
 
-
-						--moving average for smoothing
+						--moving average for smoothing using circular buffer
 						local now = event:getTicks()
-						table.insert(self.lastChirals, {value = chiralValue, ticks = now } )
+						local CHIRAL_MAX_SAMPLES = 50
 
+						-- Use circular buffer: overwrite oldest entry
+						local idx = self.chiralNextIdx
+						self.lastChirals[idx] = {value = chiralValue, ticks = now}
+						self.chiralNextIdx = (idx % CHIRAL_MAX_SAMPLES) + 1
+						self.chiralCount = math.min(self.chiralCount + 1, CHIRAL_MAX_SAMPLES)
 
-						local sampleCount = 300
-						if #self.lastChirals >= sampleCount then
-							table.remove(self.lastChirals, 1)
-						end
-
+						-- Calculate averages by scanning recent points
+						-- (Running totals are complex with age-based filtering, so we scan but with reduced sample count)
 						local chiralTotal = 0
 						local chiralPoints = 0
 						local longChiralTotal = 0
 						local longChiralPoints = 0
-						for i, entry in ipairs(self.lastChirals) do
-							local age = now - entry.ticks
---							log:error("age: ", age)
-
-							if age < 500 then
-								--only include values from last few moments
-								chiralTotal = chiralTotal + entry.value
-								chiralPoints = chiralPoints + 1
-							end
-							if age < 3000 then
-								--only include values from last few moments
-								longChiralTotal = longChiralTotal + entry.value
-								longChiralPoints = longChiralPoints + 1
+						for j = 0, self.chiralCount - 1 do
+							local entryIdx = ((self.chiralNextIdx - self.chiralCount + j - 1) % CHIRAL_MAX_SAMPLES) + 1
+							local entry = self.lastChirals[entryIdx]
+							if entry then
+								local age = now - entry.ticks
+								if age < 500 then
+									chiralTotal = chiralTotal + entry.value
+									chiralPoints = chiralPoints + 1
+								end
+								if age < 3000 then
+									longChiralTotal = longChiralTotal + entry.value
+									longChiralPoints = longChiralPoints + 1
+								end
 							end
 						end
 --						log:error("longChiralPoints ", longChiralPoints)
@@ -781,10 +797,11 @@ local function _eventHandler(self, event)
 						local byItemOnly = false
 						local threshold1 = 4
 						local threshold2 = 5.5
-						if longChiralPoints > 200 and math.abs(longPixels) > threshold2 and math.abs(pixels) > 1.5 then
+						-- Thresholds adjusted for 50-sample buffer (was 300): 200->33, 150->25
+						if longChiralPoints > 33 and math.abs(longPixels) > threshold2 and math.abs(pixels) > 1.5 then
 							dragAmountY = direction * math.abs(pixels) * math.pow(math.abs(longPixels/threshold2), 5)
 							byItemOnly = true
-						elseif longChiralPoints > 150 and math.abs(longPixels) > threshold1 and math.abs(pixels) > 2 then
+						elseif longChiralPoints > 25 and math.abs(longPixels) > threshold1 and math.abs(pixels) > 2 then
 							dragAmountY = direction * math.abs(pixels) * math.pow(math.abs(longPixels/threshold1), 3)
 							byItemOnly = false
 						else
@@ -1581,10 +1598,21 @@ function _updateWidgets(self)
 	local indexSize = (max - min) + 1
 
 
-	-- create index list
-	local indexList = {}
-	for i = min,max do
-		indexList[#indexList + 1] = i
+	-- create index list (reuse cached array to avoid garbage collection)
+	local indexList = self._indexListCache
+	if not indexList then
+		indexList = {}
+		self._indexListCache = indexList
+	end
+	-- Clear any stale entries and populate with current indices
+	local j = 1
+	for i = min, max do
+		indexList[j] = i
+		j = j + 1
+	end
+	-- Clear any extra entries from previous larger lists
+	for k = j, #indexList do
+		indexList[k] = nil
 	end
 
 	local lastSelected = self._lastSelected

--- a/src/squeezeplay/share/jive/ui/SimpleMenu.lua
+++ b/src/squeezeplay/share/jive/ui/SimpleMenu.lua
@@ -492,6 +492,9 @@ Efficiently replaces the current menu items, with I<items>.
 =cut
 --]]
 function setItems(self, items)
+	-- large menu updates are memory intensive
+	collectgarbage("collect")
+
 	self.items = items
 
 	Menu.setItems(self, self.items, #self.items)

--- a/src/squeezeplay/share/jive/ui/Window.lua
+++ b/src/squeezeplay/share/jive/ui/Window.lua
@@ -105,7 +105,7 @@ local LAYOUT_NONE             = jive.ui.LAYOUT_NONE
 
 local appletManager           = require("jive.AppletManager")
 
-local HORIZONTAL_PUSH_TRANSITION_DURATION = 500
+local HORIZONTAL_PUSH_TRANSITION_DURATION = 200
 
 -- our class
 module(...)
@@ -326,6 +326,9 @@ Show this window, adding it to the top of the window stack. The I<transition> is
 =cut
 --]]
 function show(self, transition)
+	-- keep on top of memory usage before pushing a new window
+	collectgarbage("collect")
+
 	local stack = Framework.windowStack
 
 	local idx = 1

--- a/src/squeezeplay/src/ui/jive.h
+++ b/src/squeezeplay/src/ui/jive.h
@@ -5,28 +5,27 @@
 *<touch>
 */
 
-
 #ifndef JIVE_H
 #define JIVE_H
 
 #include "common.h"
 #include "log.h"
 
-#include <SDL_image.h>
-#include <SDL_ttf.h>
 #include <SDL_gfxPrimitives.h>
+#include <SDL_image.h>
 #include <SDL_rotozoom.h>
+#include <SDL_ttf.h>
 
-
-/* target frame rate 14 fps (originally) - may be tuned per platform, should be /2 */
+/* target frame rate 14 fps (originally) - may be tuned per platform, should be
+ * /2 */
 /* updated to the max effective rate of scrolling on a fab4 */
-#define JIVE_FRAME_RATE 22
+#define JIVE_FRAME_RATE 30
 
 /* print profile information for blit's */
 #undef JIVE_PROFILE_BLIT
 
-#define MIN(a,b) (((a)<(b))?(a):(b))
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 #define JIVE_COLOR_WHITE 0xFFFFFFFF
 #define JIVE_COLOR_BLACK 0x000000FF
@@ -36,148 +35,148 @@
 #define JIVE_WH_FILL 65534
 
 typedef enum {
-	/* note ordered for left->right sort */
-        JIVE_ALIGN_CENTER = 0,
-        JIVE_ALIGN_LEFT,
-        JIVE_ALIGN_RIGHT,
-        JIVE_ALIGN_TOP,
-        JIVE_ALIGN_BOTTOM,
-        JIVE_ALIGN_TOP_LEFT,
-        JIVE_ALIGN_TOP_RIGHT,
-        JIVE_ALIGN_BOTTOM_LEFT,
-        JIVE_ALIGN_BOTTOM_RIGHT,
+  /* note ordered for left->right sort */
+  JIVE_ALIGN_CENTER = 0,
+  JIVE_ALIGN_LEFT,
+  JIVE_ALIGN_RIGHT,
+  JIVE_ALIGN_TOP,
+  JIVE_ALIGN_BOTTOM,
+  JIVE_ALIGN_TOP_LEFT,
+  JIVE_ALIGN_TOP_RIGHT,
+  JIVE_ALIGN_BOTTOM_LEFT,
+  JIVE_ALIGN_BOTTOM_RIGHT,
 } JiveAlign;
 
-
 typedef enum {
-	JIVE_LAYOUT_NORTH = 0,
-	JIVE_LAYOUT_EAST,
-	JIVE_LAYOUT_SOUTH,
-	JIVE_LAYOUT_WEST,
-	JIVE_LAYOUT_CENTER,
-	JIVE_LAYOUT_NONE,
+  JIVE_LAYOUT_NORTH = 0,
+  JIVE_LAYOUT_EAST,
+  JIVE_LAYOUT_SOUTH,
+  JIVE_LAYOUT_WEST,
+  JIVE_LAYOUT_CENTER,
+  JIVE_LAYOUT_NONE,
 } JiveLayout;
 
-
 typedef enum {
-	JIVE_LAYER_FRAME		= 0x01,
-	JIVE_LAYER_CONTENT		= 0x02,
-	JIVE_LAYER_CONTENT_OFF_STAGE	= 0x04,
-	JIVE_LAYER_CONTENT_ON_STAGE	= 0x08,
-	JIVE_LAYER_LOWER		= 0x10,
-	JIVE_LAYER_TITLE		= 0x20,
-	JIVE_LAYER_ALL			= 0xFF,
+  JIVE_LAYER_FRAME = 0x01,
+  JIVE_LAYER_CONTENT = 0x02,
+  JIVE_LAYER_CONTENT_OFF_STAGE = 0x04,
+  JIVE_LAYER_CONTENT_ON_STAGE = 0x08,
+  JIVE_LAYER_LOWER = 0x10,
+  JIVE_LAYER_TITLE = 0x20,
+  JIVE_LAYER_ALL = 0xFF,
 } JiveLayer;
 
-
 typedef enum {
-	JIVE_EVENT_NONE			= 0x00000000,
+  JIVE_EVENT_NONE = 0x00000000,
 
-	JIVE_EVENT_SCROLL		= 0x00000001,
-	JIVE_EVENT_ACTION		= 0x00000002,
-        
-	JIVE_EVENT_KEY_DOWN		= 0x00000010,
-	JIVE_EVENT_KEY_UP		= 0x00000020,
-	JIVE_EVENT_KEY_PRESS		= 0x00000040,
-	JIVE_EVENT_KEY_HOLD		= 0x00000080,
+  JIVE_EVENT_SCROLL = 0x00000001,
+  JIVE_EVENT_ACTION = 0x00000002,
 
-	JIVE_EVENT_MOUSE_DOWN		= 0x00000100,
-	JIVE_EVENT_MOUSE_UP		= 0x00000200,
-	JIVE_EVENT_MOUSE_PRESS		= 0x00000400,
-	JIVE_EVENT_MOUSE_HOLD		= 0x00000800,
-	JIVE_EVENT_MOUSE_MOVE           = 0x01000000,
-	JIVE_EVENT_MOUSE_DRAG           = 0x00100000,
-    
-	JIVE_EVENT_WINDOW_PUSH		= 0x00001000,
-	JIVE_EVENT_WINDOW_POP		= 0x00002000,
-	JIVE_EVENT_WINDOW_ACTIVE	= 0x00004000,
-	JIVE_EVENT_WINDOW_INACTIVE	= 0x00008000,
+  JIVE_EVENT_KEY_DOWN = 0x00000010,
+  JIVE_EVENT_KEY_UP = 0x00000020,
+  JIVE_EVENT_KEY_PRESS = 0x00000040,
+  JIVE_EVENT_KEY_HOLD = 0x00000080,
 
-	JIVE_EVENT_SHOW			= 0x00010000,
-	JIVE_EVENT_HIDE			= 0x00020000,
-	JIVE_EVENT_FOCUS_GAINED		= 0x00040000,
-	JIVE_EVENT_FOCUS_LOST		= 0x00080000,
+  JIVE_EVENT_MOUSE_DOWN = 0x00000100,
+  JIVE_EVENT_MOUSE_UP = 0x00000200,
+  JIVE_EVENT_MOUSE_PRESS = 0x00000400,
+  JIVE_EVENT_MOUSE_HOLD = 0x00000800,
+  JIVE_EVENT_MOUSE_MOVE = 0x01000000,
+  JIVE_EVENT_MOUSE_DRAG = 0x00100000,
 
-	JIVE_EVENT_WINDOW_RESIZE	= 0x00200000,
-	JIVE_EVENT_SWITCH		= 0x00400000,
-	JIVE_EVENT_MOTION		= 0x00800000,
+  JIVE_EVENT_WINDOW_PUSH = 0x00001000,
+  JIVE_EVENT_WINDOW_POP = 0x00002000,
+  JIVE_EVENT_WINDOW_ACTIVE = 0x00004000,
+  JIVE_EVENT_WINDOW_INACTIVE = 0x00008000,
 
-	JIVE_EVENT_CHAR_PRESS           = 0x02000000,
-	JIVE_EVENT_IR_PRESS             = 0x04000000,
-	JIVE_EVENT_IR_HOLD              = 0x08000000,
-	JIVE_EVENT_IR_UP                = 0x00000004,
-	JIVE_EVENT_IR_DOWN              = 0x20000000,
-	JIVE_EVENT_IR_REPEAT            = 0x40000000,
-	JIVE_ACTION                     = 0x10000000,
-	JIVE_EVENT_GESTURE              = 0x00000008,
+  JIVE_EVENT_SHOW = 0x00010000,
+  JIVE_EVENT_HIDE = 0x00020000,
+  JIVE_EVENT_FOCUS_GAINED = 0x00040000,
+  JIVE_EVENT_FOCUS_LOST = 0x00080000,
 
-	//Note: don't use 0x80000000, 0x40000000 is the highest usable value
-	
-	JIVE_EVENT_CHAR_ALL 	= ( JIVE_EVENT_CHAR_PRESS),
-	JIVE_EVENT_IR_ALL               = ( JIVE_EVENT_IR_PRESS | JIVE_EVENT_IR_HOLD | JIVE_EVENT_IR_UP | JIVE_EVENT_IR_DOWN | JIVE_EVENT_IR_REPEAT),
-	JIVE_EVENT_KEY_ALL		= ( JIVE_EVENT_KEY_DOWN | JIVE_EVENT_KEY_UP | JIVE_EVENT_KEY_PRESS | JIVE_EVENT_KEY_HOLD ),
-	JIVE_EVENT_MOUSE_ALL		= ( JIVE_EVENT_MOUSE_DOWN | JIVE_EVENT_MOUSE_UP | JIVE_EVENT_MOUSE_PRESS | JIVE_EVENT_MOUSE_HOLD | JIVE_EVENT_MOUSE_MOVE | JIVE_EVENT_MOUSE_DRAG ),
-	JIVE_EVENT_ALL_INPUT		= ( JIVE_EVENT_KEY_ALL | JIVE_EVENT_MOUSE_ALL | JIVE_EVENT_SCROLL | JIVE_EVENT_CHAR_ALL | JIVE_EVENT_IR_ALL | JIVE_EVENT_GESTURE),
+  JIVE_EVENT_WINDOW_RESIZE = 0x00200000,
+  JIVE_EVENT_SWITCH = 0x00400000,
+  JIVE_EVENT_MOTION = 0x00800000,
 
-	JIVE_EVENT_VISIBLE_ALL		= ( JIVE_EVENT_SHOW | JIVE_EVENT_HIDE ),
-	JIVE_EVENT_ALL			= 0x7FFFFFFF,
+  JIVE_EVENT_CHAR_PRESS = 0x02000000,
+  JIVE_EVENT_IR_PRESS = 0x04000000,
+  JIVE_EVENT_IR_HOLD = 0x08000000,
+  JIVE_EVENT_IR_UP = 0x00000004,
+  JIVE_EVENT_IR_DOWN = 0x20000000,
+  JIVE_EVENT_IR_REPEAT = 0x40000000,
+  JIVE_ACTION = 0x10000000,
+  JIVE_EVENT_GESTURE = 0x00000008,
+
+  // Note: don't use 0x80000000, 0x40000000 is the highest usable value
+
+  JIVE_EVENT_CHAR_ALL = (JIVE_EVENT_CHAR_PRESS),
+  JIVE_EVENT_IR_ALL =
+      (JIVE_EVENT_IR_PRESS | JIVE_EVENT_IR_HOLD | JIVE_EVENT_IR_UP |
+       JIVE_EVENT_IR_DOWN | JIVE_EVENT_IR_REPEAT),
+  JIVE_EVENT_KEY_ALL = (JIVE_EVENT_KEY_DOWN | JIVE_EVENT_KEY_UP |
+                        JIVE_EVENT_KEY_PRESS | JIVE_EVENT_KEY_HOLD),
+  JIVE_EVENT_MOUSE_ALL =
+      (JIVE_EVENT_MOUSE_DOWN | JIVE_EVENT_MOUSE_UP | JIVE_EVENT_MOUSE_PRESS |
+       JIVE_EVENT_MOUSE_HOLD | JIVE_EVENT_MOUSE_MOVE | JIVE_EVENT_MOUSE_DRAG),
+  JIVE_EVENT_ALL_INPUT =
+      (JIVE_EVENT_KEY_ALL | JIVE_EVENT_MOUSE_ALL | JIVE_EVENT_SCROLL |
+       JIVE_EVENT_CHAR_ALL | JIVE_EVENT_IR_ALL | JIVE_EVENT_GESTURE),
+
+  JIVE_EVENT_VISIBLE_ALL = (JIVE_EVENT_SHOW | JIVE_EVENT_HIDE),
+  JIVE_EVENT_ALL = 0x7FFFFFFF,
 } JiveEventType;
 
-
 typedef enum {
-	JIVE_EVENT_UNUSED		= 0x0000,
-	JIVE_EVENT_CONSUME		= 0x0001,
-	JIVE_EVENT_QUIT			= 0x0002,
+  JIVE_EVENT_UNUSED = 0x0000,
+  JIVE_EVENT_CONSUME = 0x0001,
+  JIVE_EVENT_QUIT = 0x0002,
 } JiveEventStatus;
 
-
 typedef enum {
-	JIVE_KEY_NONE			= 0x0000,
-	JIVE_KEY_GO			= 0x0001,
-	JIVE_KEY_BACK			= 0x0002,
-	JIVE_KEY_UP			= 0x0004,
-	JIVE_KEY_DOWN			= 0x0008,
-	JIVE_KEY_LEFT			= 0x0010,
-	JIVE_KEY_RIGHT			= 0x0020,
-	JIVE_KEY_HOME			= 0x0040,
-	JIVE_KEY_PLAY			= 0x0080,
-	JIVE_KEY_ADD			= 0x0100,
-	JIVE_KEY_PAUSE			= 0x0200,
-	JIVE_KEY_REW			= 0x0400,
-	JIVE_KEY_FWD			= 0x0800,
-	JIVE_KEY_VOLUME_UP		= 0x1000,
-	JIVE_KEY_VOLUME_DOWN		= 0x2000,
-	JIVE_KEY_PAGE_UP		= 0x4000,
-	JIVE_KEY_PAGE_DOWN		= 0x8000,
-	JIVE_KEY_PRINT			= 0x10000,
-	JIVE_KEY_PRESET_1		= 0x20000,
-	JIVE_KEY_PRESET_2		= 0x40000,
-	JIVE_KEY_PRESET_3		= 0x80000,
-	JIVE_KEY_PRESET_4		= 0x100000,
-	JIVE_KEY_PRESET_5		= 0x200000,
-	JIVE_KEY_PRESET_6		= 0x400000,
-	JIVE_KEY_ALARM			= 0x800000,
-	JIVE_KEY_MUTE			= 0x1000000,
-	JIVE_KEY_POWER			= 0x2000000,
-	JIVE_KEY_PRESET_0		= 0x4000000,
-	JIVE_KEY_PRESET_7		= 0x8000000,
-	JIVE_KEY_PRESET_8		= 0x10000000,
-	JIVE_KEY_PRESET_9		= 0x20000000,
+  JIVE_KEY_NONE = 0x0000,
+  JIVE_KEY_GO = 0x0001,
+  JIVE_KEY_BACK = 0x0002,
+  JIVE_KEY_UP = 0x0004,
+  JIVE_KEY_DOWN = 0x0008,
+  JIVE_KEY_LEFT = 0x0010,
+  JIVE_KEY_RIGHT = 0x0020,
+  JIVE_KEY_HOME = 0x0040,
+  JIVE_KEY_PLAY = 0x0080,
+  JIVE_KEY_ADD = 0x0100,
+  JIVE_KEY_PAUSE = 0x0200,
+  JIVE_KEY_REW = 0x0400,
+  JIVE_KEY_FWD = 0x0800,
+  JIVE_KEY_VOLUME_UP = 0x1000,
+  JIVE_KEY_VOLUME_DOWN = 0x2000,
+  JIVE_KEY_PAGE_UP = 0x4000,
+  JIVE_KEY_PAGE_DOWN = 0x8000,
+  JIVE_KEY_PRINT = 0x10000,
+  JIVE_KEY_PRESET_1 = 0x20000,
+  JIVE_KEY_PRESET_2 = 0x40000,
+  JIVE_KEY_PRESET_3 = 0x80000,
+  JIVE_KEY_PRESET_4 = 0x100000,
+  JIVE_KEY_PRESET_5 = 0x200000,
+  JIVE_KEY_PRESET_6 = 0x400000,
+  JIVE_KEY_ALARM = 0x800000,
+  JIVE_KEY_MUTE = 0x1000000,
+  JIVE_KEY_POWER = 0x2000000,
+  JIVE_KEY_PRESET_0 = 0x4000000,
+  JIVE_KEY_PRESET_7 = 0x8000000,
+  JIVE_KEY_PRESET_8 = 0x10000000,
+  JIVE_KEY_PRESET_9 = 0x20000000,
 } JiveKey;
 
 typedef enum {
-	JIVE_GESTURE_L_R                = 0x0001,
-	JIVE_GESTURE_R_L 	        = 0x0002,
+  JIVE_GESTURE_L_R = 0x0001,
+  JIVE_GESTURE_R_L = 0x0002,
 } JiveGesture;
 
-
 enum {
-	/* reserved: 0x00000001 */
-	/* reserved: 0x00000002 */
-	/* reserved: 0x00000003 */
-	JIVE_USER_EVENT_EVENT		= 0x00000004,
+  /* reserved: 0x00000001 */
+  /* reserved: 0x00000002 */
+  /* reserved: 0x00000003 */
+  JIVE_USER_EVENT_EVENT = 0x00000004,
 };
-
 
 typedef struct jive_peer_meta JivePeerMeta;
 
@@ -193,124 +192,122 @@ typedef struct jive_event JiveEvent;
 
 typedef struct jive_font JiveFont;
 
-
 struct jive_peer_meta {
-	size_t size;
-	const char *magic;
-	lua_CFunction gc;
+  size_t size;
+  const char *magic;
+  lua_CFunction gc;
 };
 
 struct jive_inset {
-	Uint16 left, top, right, bottom;
+  Uint16 left, top, right, bottom;
 };
 
 struct jive_widget {
-	SDL_Rect bounds;
-	SDL_Rect preferred_bounds;
-	JiveInset padding;
-	JiveInset border;
-	Uint32 skin_origin;
-	Uint32 child_origin;
-	Uint32 layout_origin;
-	JiveAlign align;
-	Uint8 layer;
-	Sint16 z_order;
-	bool hidden;
+  SDL_Rect bounds;
+  SDL_Rect preferred_bounds;
+  JiveInset padding;
+  JiveInset border;
+  Uint32 skin_origin;
+  Uint32 child_origin;
+  Uint32 layout_origin;
+  JiveAlign align;
+  Uint8 layer;
+  Sint16 z_order;
+  bool hidden;
 };
 
 struct jive_scroll_event {
-	int rel;
+  int rel;
 };
 
 struct jive_action_event {
-	int index;
+  int index;
 };
 
 struct jive_key_event {
-	JiveKey code;
+  JiveKey code;
 };
 
 struct jive_char_event {
-	Uint16 unicode;
+  Uint16 unicode;
 };
 
 struct jive_mouse_event {
-	Uint16 x;
-	Uint16 y;
-	/* extended to support touchscreens */
-	Uint16 finger_count;
-	Uint16 finger_pressure;
-	Uint16 finger_width;
-	Sint16 chiral_value;
-	bool chiral_active;
+  Uint16 x;
+  Uint16 y;
+  /* extended to support touchscreens */
+  Uint16 finger_count;
+  Uint16 finger_pressure;
+  Uint16 finger_width;
+  Sint16 chiral_value;
+  bool chiral_active;
 };
 
 struct jive_motion_event {
-	Sint16 x;
-	Sint16 y;
-	Sint16 z;
+  Sint16 x;
+  Sint16 y;
+  Sint16 z;
 };
 
 struct jive_sw_event {
-	Uint16 code;
-	Uint16 value;
+  Uint16 code;
+  Uint16 value;
 };
 
 struct jive_ir_event {
-	Uint32 code;
+  Uint32 code;
 };
 
 struct jive_gesture_event {
-	JiveGesture code;
+  JiveGesture code;
 };
 
 struct jive_event {
-	JiveEventType type;
-	Uint32 ticks;
+  JiveEventType type;
+  Uint32 ticks;
 
-	union {
-		struct jive_scroll_event scroll;
-		struct jive_action_event action;
-		struct jive_key_event key;
-		struct jive_char_event text;
-		struct jive_mouse_event mouse;
-		struct jive_motion_event motion;
-		struct jive_sw_event sw;
-		struct jive_ir_event ir;
-		struct jive_gesture_event gesture;
-	} u;
+  union {
+    struct jive_scroll_event scroll;
+    struct jive_action_event action;
+    struct jive_key_event key;
+    struct jive_char_event text;
+    struct jive_mouse_event mouse;
+    struct jive_motion_event motion;
+    struct jive_sw_event sw;
+    struct jive_ir_event ir;
+    struct jive_gesture_event gesture;
+  } u;
 };
 
 struct jive_font {
-	Uint32 refcount;
-	char *name;
-	Uint16 size;
+  Uint32 refcount;
+  char *name;
+  Uint16 size;
 
-	// Specific font functions
-	SDL_Surface *(*draw)(struct jive_font *, Uint32, const char *);
-	int (*width)(struct jive_font *, const char *);
-	void (*destroy)(struct jive_font *);
+  // Specific font functions
+  SDL_Surface *(*draw)(struct jive_font *, Uint32, const char *);
+  int (*width)(struct jive_font *, const char *);
+  void (*destroy)(struct jive_font *);
 
-	// Data for specifc font types
-	TTF_Font *ttf;
-	int height;
-	int capheight;
-	int ascend;
+  // Data for specifc font types
+  TTF_Font *ttf;
+  int height;
+  int capheight;
+  int ascend;
 
-	struct jive_font *next;
+  struct jive_font *next;
 
-	const char *magic;
+  const char *magic;
 };
 
 struct jive_perfwarn {
-	Uint32 screen;
-	Uint32 layout;
-	Uint32 draw;
-	Uint32 event;
-	int queue;
-	Uint32 garbage;
+  Uint32 screen;
+  Uint32 layout;
+  Uint32 draw;
+  Uint32 event;
+  int queue;
+  Uint32 garbage;
 };
-
 
 /* logging */
 extern LOG_CATEGORY *log_ui_draw;
@@ -324,13 +321,11 @@ void jive_send_key_event(JiveEventType keyType, JiveKey keyCode, Uint32 ticks);
 void jive_send_gesture_event(JiveGesture code);
 void jive_send_char_press_event(Uint16 unicode);
 
-
 /* platform functions */
 void platform_init(lua_State *L);
 char *platform_get_mac_address();
 char *platform_get_home_dir();
 char *platform_get_arch();
-
 
 /* global counter used to invalidate widget */
 extern Uint32 jive_origin;
@@ -339,16 +334,17 @@ extern Uint32 jive_origin;
 void jive_print_stack(lua_State *L, char *str);
 void jive_debug_traceback(lua_State *L, int n);
 int jiveL_getframework(lua_State *L);
-int jive_getmethod(lua_State *L, int index, char *method) ;
+int jive_getmethod(lua_State *L, int index, char *method);
 void *jive_getpeer(lua_State *L, int index, JivePeerMeta *peerMeta);
 void jive_torect(lua_State *L, int index, SDL_Rect *rect);
 void jive_rect_union(SDL_Rect *a, SDL_Rect *b, SDL_Rect *c);
 void jive_rect_intersection(SDL_Rect *a, SDL_Rect *b, SDL_Rect *c);
 void jive_queue_event(JiveEvent *evt);
-int jive_traceback (lua_State *L);
+int jive_traceback(lua_State *L);
 
 /* Surface functions */
-JiveSurface *jive_surface_set_video_mode(Uint16 w, Uint16 h, Uint16 bpp, bool fullscreen);
+JiveSurface *jive_surface_set_video_mode(Uint16 w, Uint16 h, Uint16 bpp,
+                                         bool fullscreen);
 JiveSurface *jive_surface_newRGB(Uint16 w, Uint16 h);
 JiveSurface *jive_surface_newRGBA(Uint16 w, Uint16 h);
 JiveSurface *jive_surface_new_SDLSurface(SDL_Surface *sdl_surface);
@@ -363,40 +359,67 @@ void jive_surface_set_offset(JiveSurface *src, Sint16 x, Sint16 y);
 void jive_surface_get_clip(JiveSurface *srf, SDL_Rect *r);
 void jive_surface_set_clip(JiveSurface *srf, SDL_Rect *r);
 void jive_surface_push_clip(JiveSurface *srf, SDL_Rect *r, SDL_Rect *pop);
-void jive_surface_set_clip_arg(JiveSurface *srf, Uint16 x, Uint16 y, Uint16 w, Uint16 h);
-void jive_surface_get_clip_arg(JiveSurface *srf, Uint16 *x, Uint16 *y, Uint16 *w, Uint16 *h);
+void jive_surface_set_clip_arg(JiveSurface *srf, Uint16 x, Uint16 y, Uint16 w,
+                               Uint16 h);
+void jive_surface_get_clip_arg(JiveSurface *srf, Uint16 *x, Uint16 *y,
+                               Uint16 *w, Uint16 *h);
 void jive_surface_flip(JiveSurface *srf);
-void jive_surface_blit(JiveSurface *src, JiveSurface *dst, Uint16 dx, Uint16 dy);
-void jive_surface_blit_clip(JiveSurface *src, Uint16 sx, Uint16 sy, Uint16 sw, Uint16 sh,
-			    JiveSurface* dst, Uint16 dx, Uint16 dy);
-void jive_surface_blit_alpha(JiveSurface *src, JiveSurface *dst, Uint16 dx, Uint16 dy, Uint8 alpha);
+void jive_surface_blit(JiveSurface *src, JiveSurface *dst, Uint16 dx,
+                       Uint16 dy);
+void jive_surface_blit_clip(JiveSurface *src, Uint16 sx, Uint16 sy, Uint16 sw,
+                            Uint16 sh, JiveSurface *dst, Uint16 dx, Uint16 dy);
+void jive_surface_blit_alpha(JiveSurface *src, JiveSurface *dst, Uint16 dx,
+                             Uint16 dy, Uint8 alpha);
 void jive_surface_get_size(JiveSurface *srf, Uint16 *w, Uint16 *h);
 int jive_surface_get_bytes(JiveSurface *srf);
 void jive_surface_free(JiveSurface *srf);
 void jive_surface_release(JiveSurface *srf);
 
 /* Encapsulated SDL_gfx functions */
-JiveSurface *jive_surface_rotozoomSurface(JiveSurface *srf, double angle, double zoom, int smooth);
-JiveSurface *jive_surface_zoomSurface(JiveSurface *srf, double zoomx, double zoomy, int smooth);
-JiveSurface *jive_surface_shrinkSurface(JiveSurface *srf, int factorx, int factory);
+JiveSurface *jive_surface_rotozoomSurface(JiveSurface *srf, double angle,
+                                          double zoom, int smooth);
+JiveSurface *jive_surface_zoomSurface(JiveSurface *srf, double zoomx,
+                                      double zoomy, int smooth);
+JiveSurface *jive_surface_shrinkSurface(JiveSurface *srf, int factorx,
+                                        int factory);
 void jive_surface_pixelColor(JiveSurface *srf, Sint16 x, Sint16 y, Uint32 col);
-void jive_surface_hlineColor(JiveSurface *srf, Sint16 x1, Sint16 x2, Sint16 y, Uint32 color);
-void jive_surface_vlineColor(JiveSurface *srf, Sint16 x, Sint16 y1, Sint16 y2, Uint32 color);
-void jive_surface_rectangleColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 col);
-void jive_surface_boxColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 col);
-void jive_surface_lineColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 col);
-void jive_surface_aalineColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint32 col);
-void jive_surface_circleColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 r, Uint32 col);
-void jive_surface_aacircleColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 r, Uint32 col);
-void jive_surface_filledCircleColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 r, Uint32 col);
-void jive_surface_ellipseColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 col);
-void jive_surface_aaellipseColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 col);
-void jive_surface_filledEllipseColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint32 col);
-void jive_surface_pieColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end, Uint32 col);
-void jive_surface_filledPieColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 rad, Sint16 start, Sint16 end, Uint32 col);
-void jive_surface_trigonColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 col);
-void jive_surface_aatrigonColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 col);
-void jive_surface_filledTrigonColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3, Uint32 col);
+void jive_surface_hlineColor(JiveSurface *srf, Sint16 x1, Sint16 x2, Sint16 y,
+                             Uint32 color);
+void jive_surface_vlineColor(JiveSurface *srf, Sint16 x, Sint16 y1, Sint16 y2,
+                             Uint32 color);
+void jive_surface_rectangleColor(JiveSurface *srf, Sint16 x1, Sint16 y1,
+                                 Sint16 x2, Sint16 y2, Uint32 col);
+void jive_surface_boxColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2,
+                           Sint16 y2, Uint32 col);
+void jive_surface_lineColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2,
+                            Sint16 y2, Uint32 col);
+void jive_surface_aalineColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2,
+                              Sint16 y2, Uint32 col);
+void jive_surface_circleColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 r,
+                              Uint32 col);
+void jive_surface_aacircleColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 r,
+                                Uint32 col);
+void jive_surface_filledCircleColor(JiveSurface *srf, Sint16 x, Sint16 y,
+                                    Sint16 r, Uint32 col);
+void jive_surface_ellipseColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 rx,
+                               Sint16 ry, Uint32 col);
+void jive_surface_aaellipseColor(JiveSurface *srf, Sint16 x, Sint16 y,
+                                 Sint16 rx, Sint16 ry, Uint32 col);
+void jive_surface_filledEllipseColor(JiveSurface *srf, Sint16 x, Sint16 y,
+                                     Sint16 rx, Sint16 ry, Uint32 col);
+void jive_surface_pieColor(JiveSurface *srf, Sint16 x, Sint16 y, Sint16 rad,
+                           Sint16 start, Sint16 end, Uint32 col);
+void jive_surface_filledPieColor(JiveSurface *srf, Sint16 x, Sint16 y,
+                                 Sint16 rad, Sint16 start, Sint16 end,
+                                 Uint32 col);
+void jive_surface_trigonColor(JiveSurface *srf, Sint16 x1, Sint16 y1, Sint16 x2,
+                              Sint16 y2, Sint16 x3, Sint16 y3, Uint32 col);
+void jive_surface_aatrigonColor(JiveSurface *srf, Sint16 x1, Sint16 y1,
+                                Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+                                Uint32 col);
+void jive_surface_filledTrigonColor(JiveSurface *srf, Sint16 x1, Sint16 y1,
+                                    Sint16 x2, Sint16 y2, Sint16 x3, Sint16 y3,
+                                    Uint32 col);
 
 /* Tile functions */
 JiveTile *jive_tile_fill_color(Uint32 col);
@@ -409,10 +432,11 @@ JiveTile *jive_tile_ref(JiveTile *tile);
 void jive_tile_get_min_size(JiveTile *tile, Uint16 *w, Uint16 *h);
 void jive_tile_set_alpha(JiveTile *tile, Uint32 flags);
 void jive_tile_free(JiveTile *tile);
-void jive_tile_blit(JiveTile *tile, JiveSurface *dst, Uint16 dx, Uint16 dy, Uint16 dw, Uint16 dh);
-void jive_tile_blit_centered(JiveTile *tile, JiveSurface *dst, Uint16 dx, Uint16 dy, Uint16 dw, Uint16 dh);
+void jive_tile_blit(JiveTile *tile, JiveSurface *dst, Uint16 dx, Uint16 dy,
+                    Uint16 dw, Uint16 dh);
+void jive_tile_blit_centered(JiveTile *tile, JiveSurface *dst, Uint16 dx,
+                             Uint16 dy, Uint16 dw, Uint16 dh);
 SDL_Surface *jive_tile_get_image_surface(JiveTile *tile);
-
 
 /* Font functions */
 JiveFont *jive_font_load(const char *name, Uint16 size);
@@ -427,9 +451,9 @@ int jive_font_capheight(JiveFont *font);
 int jive_font_ascend(JiveFont *font);
 int jive_font_offset(JiveFont *font);
 JiveSurface *jive_font_draw_text(JiveFont *font, Uint32 color, const char *str);
-JiveSurface *jive_font_ndraw_text(JiveFont *font, Uint32 color, const char *str, size_t len);
+JiveSurface *jive_font_ndraw_text(JiveFont *font, Uint32 color, const char *str,
+                                  size_t len);
 Uint32 utf8_get_char(const char *ptr, const char **nptr);
-
 
 /* C helper functions */
 void jive_redraw(SDL_Rect *r);
@@ -440,17 +464,22 @@ int jive_widget_halign(JiveWidget *this, JiveAlign align, Uint16 width);
 int jive_widget_valign(JiveWidget *this, JiveAlign align, Uint16 height);
 
 int jive_style_int(lua_State *L, int index, const char *key, int def);
-Uint32 jive_style_color(lua_State *L, int index, const char *key, Uint32 def, bool *is_set);
-JiveSurface *jive_style_image(lua_State *L, int index, const char *key, JiveSurface *def);
-JiveTile *jive_style_tile(lua_State *L, int index, const char *key, JiveTile *def);
+Uint32 jive_style_color(lua_State *L, int index, const char *key, Uint32 def,
+                        bool *is_set);
+JiveSurface *jive_style_image(lua_State *L, int index, const char *key,
+                              JiveSurface *def);
+JiveTile *jive_style_tile(lua_State *L, int index, const char *key,
+                          JiveTile *def);
 JiveFont *jive_style_font(lua_State *L, int index, const char *key);
 JiveAlign jive_style_align(lua_State *L, int index, char *key, JiveAlign def);
 void jive_style_insets(lua_State *L, int index, char *key, JiveInset *inset);
 int jive_style_array_size(lua_State *L, int index, char *key);
-int jive_style_array_int(lua_State *L, int index, const char *array, int n, const char *key, int def);
-JiveFont *jive_style_array_font(lua_State *L, int index, const char *array, int n, const char *key);
-Uint32 jive_style_array_color(lua_State *L, int index, const char *array, int n, const char *key, Uint32 def, bool *is_set);
-
+int jive_style_array_int(lua_State *L, int index, const char *array, int n,
+                         const char *key, int def);
+JiveFont *jive_style_array_font(lua_State *L, int index, const char *array,
+                                int n, const char *key);
+Uint32 jive_style_array_color(lua_State *L, int index, const char *array, int n,
+                              const char *key, Uint32 def, bool *is_set);
 
 /* lua functions */
 int jiveL_get_background(lua_State *L);
@@ -459,7 +488,7 @@ int jiveL_dispatch_event(lua_State *L);
 int jiveL_dirty(lua_State *L);
 
 int jiveL_event_new(lua_State *L);
-int jiveL_event_tostring(lua_State* L);
+int jiveL_event_tostring(lua_State *L);
 int jiveL_event_get_type(lua_State *L);
 int jiveL_event_get_ticks(lua_State *L);
 int jiveL_event_get_scroll(lua_State *L);
@@ -552,10 +581,12 @@ int jiveL_style_color(lua_State *L);
 int jiveL_style_array_color(lua_State *L);
 int jiveL_style_font(lua_State *L);
 
-
-#define JIVEL_STACK_CHECK_BEGIN(L) { int _sc = lua_gettop((L));
+#define JIVEL_STACK_CHECK_BEGIN(L)                                             \
+  {                                                                            \
+    int _sc = lua_gettop((L));
 #define JIVEL_STACK_CHECK_ASSERT(L) assert(_sc == lua_gettop((L)));
-#define JIVEL_STACK_CHECK_END(L) JIVEL_STACK_CHECK_ASSERT(L) }
-
+#define JIVEL_STACK_CHECK_END(L)                                               \
+  JIVEL_STACK_CHECK_ASSERT(L)                                                  \
+  }
 
 #endif // JIVE_H

--- a/src/squeezeplay/src/ui/jive_framework.c
+++ b/src/squeezeplay/src/ui/jive_framework.c
@@ -23,10 +23,8 @@ SDL_Rect jive_dirty_region, last_dirty_region;
 Uint32 jive_origin = 0;
 static Uint32 next_jive_origin = 0;
 
-
 /* performance warning thresholds, 0 = disabled */
-struct jive_perfwarn perfwarn = { 0, 0, 0, 0, 0, 0 };
-
+struct jive_perfwarn perfwarn = {0, 0, 0, 0, 0, 0};
 
 /* button hold threshold 1 seconds */
 #define HOLD_TIMEOUT 1000
@@ -44,25 +42,25 @@ static Uint16 screen_w, screen_h, screen_bpp;
 static bool screen_isfull = false;
 
 struct jive_keymap {
-	SDLKey keysym;
-	JiveKey keycode;
+  SDLKey keysym;
+  JiveKey keycode;
 };
 
 struct jive_keyir {
-	SDLKey keysym;
-	Uint32 code;
+  SDLKey keysym;
+  Uint32 code;
 };
 
 static enum jive_key_state {
-	KEY_STATE_NONE,
-	KEY_STATE_DOWN,
-	KEY_STATE_SENT,
+  KEY_STATE_NONE,
+  KEY_STATE_DOWN,
+  KEY_STATE_SENT,
 } key_state = KEY_STATE_NONE;
 
 static enum jive_mouse_state {
-	MOUSE_STATE_NONE,
-	MOUSE_STATE_DOWN,
-	MOUSE_STATE_SENT,
+  MOUSE_STATE_NONE,
+  MOUSE_STATE_DOWN,
+  MOUSE_STATE_SENT,
 } mouse_state = MOUSE_STATE_NONE;
 
 static JiveKey key_mask = 0;
@@ -80,55 +78,48 @@ static Uint16 mouse_origin_x, mouse_origin_y;
 static int ui_watchdog;
 
 static struct jive_keymap keymap[] = {
-	{ SDLK_RIGHT,		JIVE_KEY_GO },
-	{ SDLK_RETURN,		JIVE_KEY_GO },
-	{ SDLK_LEFT,		JIVE_KEY_BACK },
-	{ SDLK_HOME,		JIVE_KEY_HOME },
-	{ SDLK_AudioPlay,	JIVE_KEY_PLAY },
-	{ SDLK_AudioPause,	JIVE_KEY_PAUSE },
-	{ SDLK_KP_PLUS,		JIVE_KEY_ADD },
-	{ SDLK_AudioPrev,	JIVE_KEY_REW },
-	{ SDLK_AudioNext,	JIVE_KEY_FWD },
-	{ SDLK_AudioRaiseVolume,JIVE_KEY_VOLUME_UP },
-	{ SDLK_AudioLowerVolume,JIVE_KEY_VOLUME_DOWN },
-	{ SDLK_PAGEUP,		JIVE_KEY_PAGE_UP },
-	{ SDLK_PAGEDOWN,	JIVE_KEY_PAGE_DOWN },
-	{ SDLK_PRINT,		JIVE_KEY_PRINT },
-	{ SDLK_SYSREQ,		JIVE_KEY_PRINT },
-	{ SDLK_F10,             JIVE_KEY_PRESET_0 },
-	{ SDLK_F1,              JIVE_KEY_PRESET_1 },
-	{ SDLK_F2,              JIVE_KEY_PRESET_2 },
-	{ SDLK_F3,              JIVE_KEY_PRESET_3 },
-	{ SDLK_F4,              JIVE_KEY_PRESET_4 },
-	{ SDLK_F5,              JIVE_KEY_PRESET_5 },
-	{ SDLK_F6,              JIVE_KEY_PRESET_6 },
-	{ SDLK_F7,              JIVE_KEY_PRESET_7 },
-	{ SDLK_F8,              JIVE_KEY_PRESET_8 },
-	{ SDLK_F9,              JIVE_KEY_PRESET_9 },
-	{ SDLK_AudioMute,       JIVE_KEY_MUTE },
-	{ SDLK_POWER,           JIVE_KEY_POWER },
-	{ SDLK_Sleep,           JIVE_KEY_ALARM },
-	{ SDLK_UNKNOWN,		JIVE_KEY_NONE },
+    {SDLK_RIGHT, JIVE_KEY_GO},
+    {SDLK_RETURN, JIVE_KEY_GO},
+    {SDLK_LEFT, JIVE_KEY_BACK},
+    {SDLK_HOME, JIVE_KEY_HOME},
+    {SDLK_AudioPlay, JIVE_KEY_PLAY},
+    {SDLK_AudioPause, JIVE_KEY_PAUSE},
+    {SDLK_KP_PLUS, JIVE_KEY_ADD},
+    {SDLK_AudioPrev, JIVE_KEY_REW},
+    {SDLK_AudioNext, JIVE_KEY_FWD},
+    {SDLK_AudioRaiseVolume, JIVE_KEY_VOLUME_UP},
+    {SDLK_AudioLowerVolume, JIVE_KEY_VOLUME_DOWN},
+    {SDLK_PAGEUP, JIVE_KEY_PAGE_UP},
+    {SDLK_PAGEDOWN, JIVE_KEY_PAGE_DOWN},
+    {SDLK_PRINT, JIVE_KEY_PRINT},
+    {SDLK_SYSREQ, JIVE_KEY_PRINT},
+    {SDLK_F10, JIVE_KEY_PRESET_0},
+    {SDLK_F1, JIVE_KEY_PRESET_1},
+    {SDLK_F2, JIVE_KEY_PRESET_2},
+    {SDLK_F3, JIVE_KEY_PRESET_3},
+    {SDLK_F4, JIVE_KEY_PRESET_4},
+    {SDLK_F5, JIVE_KEY_PRESET_5},
+    {SDLK_F6, JIVE_KEY_PRESET_6},
+    {SDLK_F7, JIVE_KEY_PRESET_7},
+    {SDLK_F8, JIVE_KEY_PRESET_8},
+    {SDLK_F9, JIVE_KEY_PRESET_9},
+    {SDLK_AudioMute, JIVE_KEY_MUTE},
+    {SDLK_POWER, JIVE_KEY_POWER},
+    {SDLK_Sleep, JIVE_KEY_ALARM},
+    {SDLK_UNKNOWN, JIVE_KEY_NONE},
 };
 
 static struct jive_keyir irmap[] = {
-	{ SDLK_UP,       0x7689e01f }, /* arrow_up */
-	{ SDLK_DOWN,     0x7689b04f }, /* arrow_down */
-	{ SDLK_LEFT,     0x7689906f }, /* arrow_left */
-	{ SDLK_RIGHT,    0x7689d02f }, /* arrow_right */
-	{ SDLK_0,        0x76899867 },
-	{ SDLK_1,        0x7689f00f },
-	{ SDLK_2,        0x768908f7 },
-	{ SDLK_3,        0x76898877 },
-	{ SDLK_4,        0x768948b7 },
-	{ SDLK_5,        0x7689c837 },
-	{ SDLK_6,        0x768928d7 },
-	{ SDLK_7,        0x7689a857 },
-	{ SDLK_8,        0x76896897 },
-	{ SDLK_9,        0x7689e817 },
-	{ SDLK_x,        0x768910ef }, /* play */
-	{ SDLK_a,        0x7689609f }, /* add */
-	{ SDLK_UNKNOWN,	 0x0        },
+    {SDLK_UP, 0x7689e01f},    /* arrow_up */
+    {SDLK_DOWN, 0x7689b04f},  /* arrow_down */
+    {SDLK_LEFT, 0x7689906f},  /* arrow_left */
+    {SDLK_RIGHT, 0x7689d02f}, /* arrow_right */
+    {SDLK_0, 0x76899867},     {SDLK_1, 0x7689f00f}, {SDLK_2, 0x768908f7},
+    {SDLK_3, 0x76898877},     {SDLK_4, 0x768948b7}, {SDLK_5, 0x7689c837},
+    {SDLK_6, 0x768928d7},     {SDLK_7, 0x7689a857}, {SDLK_8, 0x76896897},
+    {SDLK_9, 0x7689e817},     {SDLK_x, 0x768910ef}, /* play */
+    {SDLK_a, 0x7689609f},                           /* add */
+    {SDLK_UNKNOWN, 0x0},
 };
 
 static int process_event(lua_State *L, SDL_Event *event);
@@ -136,1444 +127,1415 @@ static void process_timers(lua_State *L);
 static int filter_events(const SDL_Event *event);
 int jiveL_update_screen(lua_State *L);
 
-
-int jive_traceback (lua_State *L) {
-	lua_getfield(L, LUA_GLOBALSINDEX, "debug");
-	if (!lua_istable(L, -1)) {
-		lua_pop(L, 1);
-		return 1;
-	}
-	lua_getfield(L, -1, "traceback");
-	if (!lua_isfunction(L, -1)) {
-		lua_pop(L, 2);
-		return 1;
-	}
-	lua_pushvalue(L, 1);  /* pass error message */
-	lua_pushinteger(L, 2);  /* skip this function and traceback */
-	lua_call(L, 2, 1);  /* call debug.traceback */
-	return 1;
+int jive_traceback(lua_State *L) {
+  lua_getfield(L, LUA_GLOBALSINDEX, "debug");
+  if (!lua_istable(L, -1)) {
+    lua_pop(L, 1);
+    return 1;
+  }
+  lua_getfield(L, -1, "traceback");
+  if (!lua_isfunction(L, -1)) {
+    lua_pop(L, 2);
+    return 1;
+  }
+  lua_pushvalue(L, 1);   /* pass error message */
+  lua_pushinteger(L, 2); /* skip this function and traceback */
+  lua_call(L, 2, 1);     /* call debug.traceback */
+  return 1;
 }
 
-
 static int jiveL_initSDL(lua_State *L) {
-	const SDL_VideoInfo *video_info;
+  const SDL_VideoInfo *video_info;
 #ifndef JIVE_NO_DISPLAY
-	JiveSurface *srf, *splash, *icon;
-	Uint16 splash_w, splash_h;
+  JiveSurface *srf, *splash, *icon;
+  Uint16 splash_w, splash_h;
 #endif
-	/* logging */
-	log_ui_draw = LOG_CATEGORY_GET("squeezeplay.ui.draw");
-	log_ui = LOG_CATEGORY_GET("squeezeplay.ui");
+  /* logging */
+  log_ui_draw = LOG_CATEGORY_GET("squeezeplay.ui.draw");
+  log_ui = LOG_CATEGORY_GET("squeezeplay.ui");
 
-	/* linux fbcon does not need a mouse */
-	SDL_putenv("SDL_NOMOUSE=1");
+  /* linux fbcon does not need a mouse */
+  SDL_putenv("SDL_NOMOUSE=1");
 
 #ifdef JIVE_NO_DISPLAY
-#   define JIVE_SDL_FEATURES (SDL_INIT_EVENTLOOP)
+#define JIVE_SDL_FEATURES (SDL_INIT_EVENTLOOP)
 #else
-#   define JIVE_SDL_FEATURES (SDL_INIT_VIDEO)
+#define JIVE_SDL_FEATURES (SDL_INIT_VIDEO)
 #endif
-	/* initialise SDL */
-	if (SDL_Init(JIVE_SDL_FEATURES) < 0) {
-		LOG_ERROR(log_ui_draw, "SDL_Init(V|T|A): %s\n", SDL_GetError());
-		SDL_Quit();
-		exit(-1);
-	}
+  /* initialise SDL */
+  if (SDL_Init(JIVE_SDL_FEATURES) < 0) {
+    LOG_ERROR(log_ui_draw, "SDL_Init(V|T|A): %s\n", SDL_GetError());
+    SDL_Quit();
+    exit(-1);
+  }
 
-	/* report video info */
-	if ((video_info = SDL_GetVideoInfo())) {
-		LOG_INFO(log_ui_draw, "%d,%d %d bits/pixel %d bytes/pixel [R<<%d G<<%d B<<%d]", video_info->current_w, video_info->current_h, video_info->vfmt->BitsPerPixel, video_info->vfmt->BytesPerPixel, video_info->vfmt->Rshift, video_info->vfmt->Gshift, video_info->vfmt->Bshift);
-		LOG_INFO(log_ui_draw, "Hardware acceleration %s available", video_info->hw_available?"is":"is not");
-	}
+  /* report video info */
+  if ((video_info = SDL_GetVideoInfo())) {
+    LOG_INFO(log_ui_draw,
+             "%d,%d %d bits/pixel %d bytes/pixel [R<<%d G<<%d B<<%d]",
+             video_info->current_w, video_info->current_h,
+             video_info->vfmt->BitsPerPixel, video_info->vfmt->BytesPerPixel,
+             video_info->vfmt->Rshift, video_info->vfmt->Gshift,
+             video_info->vfmt->Bshift);
+    LOG_INFO(log_ui_draw, "Hardware acceleration %s available",
+             video_info->hw_available ? "is" : "is not");
+  }
 
-	/* Register callback for additional events (used for multimedia keys)*/
-	SDL_EventState(SDL_SYSWMEVENT,SDL_ENABLE);
-	SDL_SetEventFilter(filter_events);
+  /* Register callback for additional events (used for multimedia keys)*/
+  SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
+  SDL_SetEventFilter(filter_events);
 
-	platform_init(L);
+  platform_init(L);
 
 #ifndef JIVE_NO_DISPLAY
 
-	/* open window */
-	SDL_WM_SetCaption("SqueezePlay Beta", "SqueezePlay Beta");
-	SDL_ShowCursor(SDL_DISABLE);
-	SDL_EnableKeyRepeat (100, 100);
-	SDL_EnableUNICODE(1);
+  /* open window */
+  SDL_WM_SetCaption("SqueezePlay Beta", "SqueezePlay Beta");
+  SDL_ShowCursor(SDL_DISABLE);
+  SDL_EnableKeyRepeat(100, 100);
+  SDL_EnableUNICODE(1);
 
-	/* load the icon */
-	icon = jive_surface_load_image("jive/app.png");
-	if (icon) {
-		jive_surface_set_wm_icon(icon);
-		jive_surface_free(icon);
-	}
+  /* load the icon */
+  icon = jive_surface_load_image("jive/app.png");
+  if (icon) {
+    jive_surface_set_wm_icon(icon);
+    jive_surface_free(icon);
+  }
 
 #ifdef SCREEN_ROTATION_ENABLED
-	screen_w = video_info->current_h;
-	screen_h = video_info->current_w;
+  screen_w = video_info->current_h;
+  screen_h = video_info->current_w;
 #else
-	screen_w = video_info->current_w;
-	screen_h = video_info->current_h;
+  screen_w = video_info->current_w;
+  screen_h = video_info->current_h;
 #endif
-	screen_bpp = video_info->vfmt->BitsPerPixel;
+  screen_bpp = video_info->vfmt->BitsPerPixel;
 
-	if (video_info->wm_available) {
-		/* desktop build */
-		splash = jive_surface_load_image("jive/splash.png");
-		if (splash) {
-			jive_surface_get_size(splash, &splash_w, &splash_h);
+  if (video_info->wm_available) {
+    /* desktop build */
+    splash = jive_surface_load_image("jive/splash.png");
+    if (splash) {
+      jive_surface_get_size(splash, &splash_w, &splash_h);
 
-			screen_w = splash_w;
-			screen_h = splash_h;
-		}
-	}
-	else {
-		/* product build */
-		char splashfile[40];
+      screen_w = splash_w;
+      screen_h = splash_h;
+    }
+  } else {
+    /* product build */
+    char splashfile[40];
 
-		sprintf(splashfile, "jive/splash%dx%d.png", screen_w, screen_h);
+    sprintf(splashfile, "jive/splash%dx%d.png", screen_w, screen_h);
 
-		splash = jive_surface_load_image(splashfile);
-		if (splash) {
-			jive_surface_get_size(splash, &splash_w, &splash_h);
-		}
-	}
+    splash = jive_surface_load_image(splashfile);
+    if (splash) {
+      jive_surface_get_size(splash, &splash_w, &splash_h);
+    }
+  }
 
-	srf = jive_surface_set_video_mode(screen_w, screen_h, screen_bpp, false);
-	if (!srf) {
-		SDL_Quit();
-		exit(-1);
-	}
+  srf = jive_surface_set_video_mode(screen_w, screen_h, screen_bpp, false);
+  if (!srf) {
+    SDL_Quit();
+    exit(-1);
+  }
 
-	if (splash) {
-		jive_surface_blit(splash, srf, MIN(0, (screen_w - splash_w) / 2), MIN(0, (screen_h - splash_h) / 2));
-		jive_surface_flip(srf);
-	}
+  if (splash) {
+    jive_surface_blit(splash, srf, MIN(0, (screen_w - splash_w) / 2),
+                      MIN(0, (screen_h - splash_h) / 2));
+    jive_surface_flip(srf);
+  }
 
-	lua_getfield(L, 1, "screen");
-	if (lua_isnil(L, -1)) {
-		LOG_ERROR(log_ui_draw, "no screen table");
+  lua_getfield(L, 1, "screen");
+  if (lua_isnil(L, -1)) {
+    LOG_ERROR(log_ui_draw, "no screen table");
 
-		SDL_Quit();
-		exit(-1);
-	}
+    SDL_Quit();
+    exit(-1);
+  }
 
-	/* store screen surface */
-	tolua_pushusertype(L, srf, "Surface");
-	lua_setfield(L, -2, "surface");
+  /* store screen surface */
+  tolua_pushusertype(L, srf, "Surface");
+  lua_setfield(L, -2, "surface");
 
-	lua_getfield(L, -1, "bounds");
-	lua_pushinteger(L, screen_w);
-	lua_rawseti(L, -2, 3);
-	lua_pushinteger(L, screen_h);
-	lua_rawseti(L, -2, 4);
-	lua_pop(L, 2);
+  lua_getfield(L, -1, "bounds");
+  lua_pushinteger(L, screen_w);
+  lua_rawseti(L, -2, 3);
+  lua_pushinteger(L, screen_h);
+  lua_rawseti(L, -2, 4);
+  lua_pop(L, 2);
 
-	/* background image */
-	jive_background = jive_tile_fill_color(0x000000FF);
+  /* background image */
+  jive_background = jive_tile_fill_color(0x000000FF);
 
-	/* jive.ui.style = {} */
-	lua_getglobal(L, "jive");
-	lua_getfield(L, -1, "ui");
-	lua_newtable(L);
-	lua_setfield(L, -2, "style");
-	lua_pop(L, 2);
+  /* jive.ui.style = {} */
+  lua_getglobal(L, "jive");
+  lua_getfield(L, -1, "ui");
+  lua_newtable(L);
+  lua_setfield(L, -2, "style");
+  lua_pop(L, 2);
 
-	ui_watchdog = watchdog_get();
-	watchdog_keepalive(ui_watchdog, 6); /* 60 seconds to start */
+  ui_watchdog = watchdog_get();
+  watchdog_keepalive(ui_watchdog, 6); /* 60 seconds to start */
 
 #endif /* JIVE_NO_DISPLAY */
 
-	return 0;
+  return 0;
 }
 
-static int filter_events(const SDL_Event *event)
-{
-	if (jive_sdlfilter_pump) {
-		return jive_sdlfilter_pump(event);
-	}
-	
-	return 1;
+static int filter_events(const SDL_Event *event) {
+  if (jive_sdlfilter_pump) {
+    return jive_sdlfilter_pump(event);
+  }
+
+  return 1;
 }
 
 void jive_send_key_event(JiveEventType keyType, JiveKey keyCode, Uint32 ticks) {
-	JiveEvent keyEvent;
-	memset(&keyEvent, 0, sizeof(JiveEvent));
-	
-	keyEvent.type = keyType;
-	keyEvent.ticks = ticks;
-	keyEvent.u.key.code = keyCode;
-	jive_queue_event(&keyEvent);
+  JiveEvent keyEvent;
+  memset(&keyEvent, 0, sizeof(JiveEvent));
+
+  keyEvent.type = keyType;
+  keyEvent.ticks = ticks;
+  keyEvent.u.key.code = keyCode;
+  jive_queue_event(&keyEvent);
 }
 
 void jive_send_gesture_event(JiveGesture code) {
-	JiveEvent event;
-	memset(&event, 0, sizeof(JiveEvent));
+  JiveEvent event;
+  memset(&event, 0, sizeof(JiveEvent));
 
-	event.type = JIVE_EVENT_GESTURE;
-	event.ticks = jive_jiffies();
-	event.u.gesture.code = code;
-	jive_queue_event(&event);
+  event.type = JIVE_EVENT_GESTURE;
+  event.ticks = jive_jiffies();
+  event.u.gesture.code = code;
+  jive_queue_event(&event);
 }
 
 void jive_send_char_press_event(Uint16 unicode) {
-	JiveEvent event;
-	memset(&event, 0, sizeof(JiveEvent));
+  JiveEvent event;
+  memset(&event, 0, sizeof(JiveEvent));
 
-	event.type = JIVE_EVENT_CHAR_PRESS;
-	event.ticks = jive_jiffies();
-	event.u.text.unicode = unicode;
-	jive_queue_event(&event);
+  event.type = JIVE_EVENT_CHAR_PRESS;
+  event.ticks = jive_jiffies();
+  event.u.text.unicode = unicode;
+  jive_queue_event(&event);
 }
-
 
 static int jiveL_quit(lua_State *L) {
 
-	/* de-reference all windows */
-	jiveL_getframework(L);
-	lua_pushnil(L);
-	lua_setfield(L, -2, "windowStack");
-	lua_pop(L, 1);
+  /* de-reference all windows */
+  jiveL_getframework(L);
+  lua_pushnil(L);
+  lua_setfield(L, -2, "windowStack");
+  lua_pop(L, 1);
 
-	/* force lua GC */
-	lua_gc(L, LUA_GCCOLLECT, 0);
+  /* force lua GC */
+  lua_gc(L, LUA_GCCOLLECT, 0);
 
-	/* quit SDL */
-	SDL_Quit();
+  /* quit SDL */
+  SDL_Quit();
 
-	return 0;
+  return 0;
 }
-
 
 static int jiveL_process_events(lua_State *L) {
-	Uint32 r = 0;
-	SDL_Event event;
+  Uint32 r = 0;
+  SDL_Event event;
 
-	/* stack:
-	 * 1 : jive.ui.Framework
-	 */
+  /* stack:
+   * 1 : jive.ui.Framework
+   */
 
-	JIVEL_STACK_CHECK_BEGIN(L);
+  JIVEL_STACK_CHECK_BEGIN(L);
 
-	/* Exit if we have no windows */
-	lua_getfield(L, 1, "windowStack");
-	if (lua_objlen(L, -1) == 0) {
-		lua_pop(L, 1);
+  /* Exit if we have no windows */
+  lua_getfield(L, 1, "windowStack");
+  if (lua_objlen(L, -1) == 0) {
+    lua_pop(L, 1);
 
-		lua_pushboolean(L, 0);
-		return 1;
-	}
-	lua_rawgeti(L, -1, 1);
+    lua_pushboolean(L, 0);
+    return 1;
+  }
+  lua_rawgeti(L, -1, 1);
 
+  /* pump keyboard/mouse events once per frame */
+  SDL_PumpEvents();
 
-	/* pump keyboard/mouse events once per frame */
-	SDL_PumpEvents();
+  if (jive_sdlevent_pump) {
+    jive_sdlevent_pump(L);
+  }
 
-	if (jive_sdlevent_pump) {
-		jive_sdlevent_pump(L);
-	}
+  /* check queue size */
+  if (perfwarn.queue) {
+    if (SDL_EventQueueLength() > perfwarn.queue) {
+      printf("SDL_event_queue > %2d : %3d\n", perfwarn.queue,
+             SDL_EventQueueLength());
+    }
+  }
 
-	/* check queue size */
-	if (perfwarn.queue) {
-		if (SDL_EventQueueLength() > perfwarn.queue) {
-			printf("SDL_event_queue > %2d : %3d\n", perfwarn.queue, SDL_EventQueueLength());
-		}
-	}
+  /* process events */
+  process_timers(L);
+  while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_ALLEVENTS) > 0) {
+    r |= process_event(L, &event);
+  }
 
-	/* process events */
-	process_timers(L);
-	while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_ALLEVENTS) > 0 ) {
-		r |= process_event(L, &event);
-	}
+  lua_pop(L, 2);
 
-	lua_pop(L, 2);
-	
-	JIVEL_STACK_CHECK_END(L);
+  JIVEL_STACK_CHECK_END(L);
 
-	if (r & JIVE_EVENT_QUIT) {
-		lua_pushboolean(L, 0);
-		return 1;
-	}
+  if (r & JIVE_EVENT_QUIT) {
+    lua_pushboolean(L, 0);
+    return 1;
+  }
 
-	lua_pushboolean(L, 1);
-	return lua_yield(L, 1);
+  lua_pushboolean(L, 1);
+  return lua_yield(L, 1);
 }
-
 
 int jiveL_set_update_screen(lua_State *L) {
-	/* stack is:
-	 * 1: framework
-	 * 2: enable/disable screen updates
-	 */
+  /* stack is:
+   * 1: framework
+   * 2: enable/disable screen updates
+   */
 
-	bool old_update_screen = update_screen;
-	update_screen = lua_toboolean(L, 2);
+  bool old_update_screen = update_screen;
+  update_screen = lua_toboolean(L, 2);
 
-	if (update_screen && !old_update_screen) {
-		/* cancel any pending transitions */
-		lua_pushnil(L);
-		lua_setfield(L, 1, "transition");
+  if (update_screen && !old_update_screen) {
+    /* cancel any pending transitions */
+    lua_pushnil(L);
+    lua_setfield(L, 1, "transition");
 
-		/* redraw now */
-		lua_pushcfunction(L, jiveL_update_screen);
-		lua_pushvalue(L, 1);
-		lua_call(L, 1, 0);
+    /* redraw now */
+    lua_pushcfunction(L, jiveL_update_screen);
+    lua_pushvalue(L, 1);
+    lua_call(L, 1, 0);
 
-		/* short delay to allow video buffer to flip */
-		SDL_Delay(50);
-	}
+    /* short delay to allow video buffer to flip */
+    SDL_Delay(10);
+  }
 
-	return 0;
+  return 0;
 }
 
-
 static int _draw_screen(lua_State *L) {
-	JiveSurface *srf;
-	Uint32 t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0;
-	clock_t c0 = 0, c1 = 0;
-	bool_t standalone_draw, drawn = false;
+  JiveSurface *srf;
+  Uint32 t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0;
+  clock_t c0 = 0, c1 = 0;
+  bool_t standalone_draw, drawn = false;
 
+  JIVEL_STACK_CHECK_BEGIN(L);
 
-	JIVEL_STACK_CHECK_BEGIN(L);
+  /* stack is:
+   * 1: framework
+   * 2: surface (in screen format)
+   * 3: standalone_draw (used to draw screen to a new surface)
+   */
 
-	/* stack is:
-	 * 1: framework
-	 * 2: surface (in screen format)
-	 * 3: standalone_draw (used to draw screen to a new surface)
-	 */
+  srf = tolua_tousertype(L, 2, 0);
+  standalone_draw = lua_toboolean(L, 3);
 
-	srf = tolua_tousertype(L, 2, 0);
-	standalone_draw = lua_toboolean(L, 3);
+  /* Exit if we have no windows, nothing to draw */
+  lua_getfield(L, 1, "windowStack");
+  if (lua_objlen(L, -1) == 0) {
+    lua_pop(L, 2);
 
-	/* Exit if we have no windows, nothing to draw */
-	lua_getfield(L, 1, "windowStack");
-	if (lua_objlen(L, -1) == 0) {
-		lua_pop(L, 2);
+    JIVEL_STACK_CHECK_ASSERT(L);
+    return 0;
+  }
+  lua_rawgeti(L, -1, 1); // topwindow
 
-		JIVEL_STACK_CHECK_ASSERT(L);
-		return 0;
-	}
-	lua_rawgeti(L, -1, 1);	// topwindow
+  if (perfwarn.screen) {
+    t0 = jive_jiffies();
+    c0 = clock();
+  }
 
-	if (perfwarn.screen) {
-		t0 = jive_jiffies();
-		c0 = clock();
-	}
+  do {
+    jive_origin = next_jive_origin;
 
+    /* Layout window and widgets */
+    if (jive_getmethod(L, -1, "checkLayout")) {
+      lua_pushvalue(L, -2);
+      lua_call(L, 1, 0);
+    }
 
-	do {
-		jive_origin = next_jive_origin;
+    /* check in case the origin changes during layout */
+  } while (jive_origin != next_jive_origin);
 
-		/* Layout window and widgets */
-		if (jive_getmethod(L, -1, "checkLayout")) {
-			lua_pushvalue(L, -2);
-			lua_call(L, 1, 0);
-		}
+  if (perfwarn.screen)
+    t1 = jive_jiffies();
 
-		/* check in case the origin changes during layout */
-	} while (jive_origin != next_jive_origin);
+  /* Widget animations - don't update in a standalone draw as its not the main
+   * screen update */
+  if (!standalone_draw) {
+    lua_getfield(L, 1, "animations");
+    lua_pushnil(L);
+    while (lua_next(L, -2) != 0) {
+      lua_getfield(L, -1, "animations");
+      lua_pushnil(L);
+      while (lua_next(L, -2) != 0) {
+        int frame;
 
-	if (perfwarn.screen) t1 = jive_jiffies();
- 
-	/* Widget animations - don't update in a standalone draw as its not the main screen update */
-	if (!standalone_draw) {
-		lua_getfield(L, 1, "animations");
-		lua_pushnil(L);
-		while (lua_next(L, -2) != 0) {
-			lua_getfield(L, -1, "animations");
-			lua_pushnil(L);
-			while (lua_next(L, -2) != 0) {
-				int frame;
-				
-				/* stack is:
-				 * -2: key
-				 * -1: table
-				 */
-				lua_rawgeti(L, -1, 2);
-				frame = lua_tointeger(L, -1) - 1;
-				
-				if (frame == 0) {
-					lua_rawgeti(L, -2, 1); // function
-					lua_pushvalue(L, -6); // widget
-					lua_call(L, 1, 0);
-					// function is poped by lua_call
-					
-					lua_rawgeti(L, -2, 3);
-					lua_rawseti(L, -3, 2);
-				}
-				else {
-				  lua_pushinteger(L, frame);
-				  lua_rawseti(L, -3, 2);
-				}
-				lua_pop(L, 2);
-			}
-			lua_pop(L, 2);
-		}
-		lua_pop(L, 1);
-	}
+        /* stack is:
+         * -2: key
+         * -1: table
+         */
+        lua_rawgeti(L, -1, 2);
+        frame = lua_tointeger(L, -1) - 1;
 
-	if (perfwarn.screen) t2 = jive_jiffies();
+        if (frame == 0) {
+          lua_rawgeti(L, -2, 1); // function
+          lua_pushvalue(L, -6);  // widget
+          lua_call(L, 1, 0);
+          // function is poped by lua_call
 
-	/* Window transitions */
-	lua_getfield(L, 1, "transition");
-	if (!lua_isnil(L, -1)) {
-		/* Draw background */
-		jive_surface_set_clip(srf, NULL);
-		jive_tile_set_alpha(jive_background, 0); // no alpha channel
-		jive_tile_blit(jive_background, srf, 0, 0, screen_w, screen_h);
+          lua_rawgeti(L, -2, 3);
+          lua_rawseti(L, -3, 2);
+        } else {
+          lua_pushinteger(L, frame);
+          lua_rawseti(L, -3, 2);
+        }
+        lua_pop(L, 2);
+      }
+      lua_pop(L, 2);
+    }
+    lua_pop(L, 1);
+  }
 
-		if (perfwarn.screen) t3 = jive_jiffies();
-		
-		/* Animate screen transition */
-		lua_pushvalue(L, -1);
-		lua_pushvalue(L, -3);  	// widget
-		lua_pushvalue(L, 2);	// surface
-		lua_call(L, 2, 0);
+  if (perfwarn.screen)
+    t2 = jive_jiffies();
 
-		drawn = true;
-	}
-	else if (jive_dirty_region.w || standalone_draw) {
-		SDL_Rect dirty;
+  /* Window transitions */
+  lua_getfield(L, 1, "transition");
+  if (!lua_isnil(L, -1)) {
+    /* Draw background */
+    jive_surface_set_clip(srf, NULL);
+    jive_tile_set_alpha(jive_background, 0); // no alpha channel
+    jive_tile_blit(jive_background, srf, 0, 0, screen_w, screen_h);
 
-		/* only redraw dirty region for non standalone draws */
-		if (!standalone_draw) {
-			jive_rect_union(&jive_dirty_region, &last_dirty_region, &dirty);
-			jive_surface_set_clip(srf, &dirty);
-		}
+    if (perfwarn.screen)
+      t3 = jive_jiffies();
+
+    /* Animate screen transition */
+    lua_pushvalue(L, -1);
+    lua_pushvalue(L, -3); // widget
+    lua_pushvalue(L, 2);  // surface
+    lua_call(L, 2, 0);
+
+    drawn = true;
+  } else if (jive_dirty_region.w || standalone_draw) {
+    SDL_Rect dirty;
+
+    /* only redraw dirty region for non standalone draws */
+    if (!standalone_draw) {
+      jive_rect_union(&jive_dirty_region, &last_dirty_region, &dirty);
+      jive_surface_set_clip(srf, &dirty);
+    }
 
 #if 0
 		printf("REDRAW: %d,%d %dx%d\n", jive_dirty_region.x, jive_dirty_region.y, jive_dirty_region.w, jive_dirty_region.h);
 		printf("--> %d,%d %dx%d\n", dirty.x, dirty.y, dirty.w, dirty.h);
 #endif
 
-		/* Draw background */
-		jive_tile_blit(jive_background, srf, 0, 0, screen_w, screen_h);
+    /* Draw background */
+    jive_tile_blit(jive_background, srf, 0, 0, screen_w, screen_h);
 
-		if (perfwarn.screen) t3 = jive_jiffies();
+    if (perfwarn.screen)
+      t3 = jive_jiffies();
 
-		/* Draw screen */
-		if (jive_getmethod(L, -2, "draw")) {
-			lua_pushvalue(L, -3);	// widget
-			lua_pushvalue(L, 2);	// surface
-			lua_pushinteger(L, JIVE_LAYER_ALL); // layer
-			lua_call(L, 3, 0);
-		}
+    /* Draw screen */
+    if (jive_getmethod(L, -2, "draw")) {
+      lua_pushvalue(L, -3);               // widget
+      lua_pushvalue(L, 2);                // surface
+      lua_pushinteger(L, JIVE_LAYER_ALL); // layer
+      lua_call(L, 3, 0);
+    }
 
 #if 0
 		// show the dirty region for debug purposes:
 		jive_surface_rectangleColor(srf, jive_dirty_region.x, jive_dirty_region.y,
 			jive_dirty_region.x + jive_dirty_region.w, jive_dirty_region.y + jive_dirty_region.h, 0xFFFFFFFF);
-#endif	
+#endif
 
-		/* clear the dirty region for non standalone draws */
-		if (!standalone_draw) {
-			memcpy(&last_dirty_region, &jive_dirty_region, sizeof(last_dirty_region));
-			jive_dirty_region.w = 0;
-		}
+    /* clear the dirty region for non standalone draws */
+    if (!standalone_draw) {
+      memcpy(&last_dirty_region, &jive_dirty_region, sizeof(last_dirty_region));
+      jive_dirty_region.w = 0;
+    }
 
-		drawn = true;
-	}
+    drawn = true;
+  }
 
-	if (perfwarn.screen) {
-		t4 = jive_jiffies();
-		c1 = clock();
-		if (t4-t0 > perfwarn.screen) {
-			if (!t3) {
-				t3 = t2;
-			}
-			printf("update_screen > %dms: %4dms (%dms) [layout:%dms animate:%dms background:%dms draw:%dms]\n",
-				   perfwarn.screen, t4-t0, (int)((c1-c0) * 1000 / CLOCKS_PER_SEC), t1-t0, t2-t1, t3-t2, t4-t3);
-		}
-	}
-	
-	lua_pop(L, 3);
+  if (perfwarn.screen) {
+    t4 = jive_jiffies();
+    c1 = clock();
+    if (t4 - t0 > perfwarn.screen) {
+      if (!t3) {
+        t3 = t2;
+      }
+      printf("update_screen > %dms: %4dms (%dms) [layout:%dms animate:%dms "
+             "background:%dms draw:%dms]\n",
+             perfwarn.screen, t4 - t0, (int)((c1 - c0) * 1000 / CLOCKS_PER_SEC),
+             t1 - t0, t2 - t1, t3 - t2, t4 - t3);
+    }
+  }
 
-	JIVEL_STACK_CHECK_END(L);
+  lua_pop(L, 3);
 
-	lua_pushboolean(L, drawn);
-	return 1;
+  JIVEL_STACK_CHECK_END(L);
+
+  lua_pushboolean(L, drawn);
+  return 1;
 }
-
 
 int jiveL_draw(lua_State *L) {
-	/* stack is:
-	 * 1: framework
-	 * 2: surface
-	 */
+  /* stack is:
+   * 1: framework
+   * 2: surface
+   */
 
-	lua_pushcfunction(L, jive_traceback);  /* push traceback function */
+  lua_pushcfunction(L, jive_traceback); /* push traceback function */
 
-	lua_pushcfunction(L, _draw_screen);
-	lua_pushvalue(L, 1);
-	lua_pushvalue(L, 2);
-	lua_pushboolean(L, 1);                 /* draw complete screen without updating animation or dirty regions */ 
+  lua_pushcfunction(L, _draw_screen);
+  lua_pushvalue(L, 1);
+  lua_pushvalue(L, 2);
+  lua_pushboolean(
+      L,
+      1); /* draw complete screen without updating animation or dirty regions */
 
-	if (lua_pcall(L, 3, 0, 3) != 0) {
-		LOG_WARN(log_ui_draw, "error in draw_screen:\n\t%s\n", lua_tostring(L, -1));
-		return 0;
-	}
+  if (lua_pcall(L, 3, 0, 3) != 0) {
+    LOG_WARN(log_ui_draw, "error in draw_screen:\n\t%s\n", lua_tostring(L, -1));
+    return 0;
+  }
 
-	lua_pop(L, 1);
+  lua_pop(L, 1);
 
-	return 0;
+  return 0;
 }
-
 
 int jiveL_update_screen(lua_State *L) {
-	JiveSurface *screen;
+  JiveSurface *screen;
 
-	/* stack is:
-	 * 1: framework
-	 */
+  /* stack is:
+   * 1: framework
+   */
 
-	/* ping watchdog */
-	// FIXME 30 seconds
-	watchdog_keepalive(ui_watchdog, 3);
+  /* ping watchdog */
+  // FIXME 40 seconds
+  watchdog_keepalive(ui_watchdog, 4);
 
-	if (!update_screen) {
-		return 0;
-	}
+  if (!update_screen) {
+    return 0;
+  }
 
-	lua_pushcfunction(L, jive_traceback);  /* push traceback function */
+  lua_pushcfunction(L, jive_traceback); /* push traceback function */
 
-	lua_pushcfunction(L, _draw_screen);
-	lua_pushvalue(L, 1);
+  lua_pushcfunction(L, _draw_screen);
+  lua_pushvalue(L, 1);
 
-	lua_getfield(L, 1, "screen");
-	lua_getfield(L, -1, "surface");
-	lua_replace(L, -2);
-	screen = tolua_tousertype(L, -1, 0);
+  lua_getfield(L, 1, "screen");
+  lua_getfield(L, -1, "surface");
+  lua_replace(L, -2);
+  screen = tolua_tousertype(L, -1, 0);
 
-	lua_pushboolean(L, 0);
+  lua_pushboolean(L, 0);
 
-	if (lua_pcall(L, 3, 1, 2) != 0) {
-		LOG_WARN(log_ui_draw, "error in update_screen:\n\t%s\n", lua_tostring(L, -1));
-		return 0;
-	}
+  if (lua_pcall(L, 3, 1, 2) != 0) {
+    LOG_WARN(log_ui_draw, "error in update_screen:\n\t%s\n",
+             lua_tostring(L, -1));
+    return 0;
+  }
 
-	/* flip screen */
-	if (lua_toboolean(L, -1)) {
-		jive_surface_flip(screen);
-	}
+  /* flip screen */
+  if (lua_toboolean(L, -1)) {
+    jive_surface_flip(screen);
+  }
 
-	lua_pop(L, 2);
+  lua_pop(L, 2);
 
-	return 0;
+  return 0;
 }
-
 
 void jive_redraw(SDL_Rect *r) {
-	if (jive_dirty_region.w) {
-		jive_rect_union(&jive_dirty_region, r, &jive_dirty_region);
-	}
-	else {
-		memcpy(&jive_dirty_region, r, sizeof(jive_dirty_region));
-	}
+  if (jive_dirty_region.w) {
+    jive_rect_union(&jive_dirty_region, r, &jive_dirty_region);
+  } else {
+    memcpy(&jive_dirty_region, r, sizeof(jive_dirty_region));
+  }
 
-	//printf("DIRTY: %d,%d %dx%d\n", jive_dirty_region.x, jive_dirty_region.y, jive_dirty_region.w, jive_dirty_region.h);
+  // printf("DIRTY: %d,%d %dx%d\n", jive_dirty_region.x, jive_dirty_region.y,
+  // jive_dirty_region.w, jive_dirty_region.h);
 }
-
 
 int jiveL_redraw(lua_State *L) {
-	SDL_Rect r;
+  SDL_Rect r;
 
-	/* stack top:
-	 * -2: framework
-	 * -1: rectangle or nil
-	 */
+  /* stack top:
+   * -2: framework
+   * -1: rectangle or nil
+   */
 
-	if (lua_isnil(L, -1)) {
-		r.x = 0;
-		r.y = 0;
-		r.w = screen_w;
-		r.h = screen_h;
-	}
-	else {
-		jive_torect(L, 2, &r);
-	}
-	lua_pop(L, 1);
+  if (lua_isnil(L, -1)) {
+    r.x = 0;
+    r.y = 0;
+    r.w = screen_w;
+    r.h = screen_h;
+  } else {
+    jive_torect(L, 2, &r);
+  }
+  lua_pop(L, 1);
 
-	jive_redraw(&r);
+  jive_redraw(&r);
 
-	return 0;
+  return 0;
 }
-
 
 int jiveL_style_changed(lua_State *L) {
 
-	/* stack top:
-	 * 1: framework
-	 */
+  /* stack top:
+   * 1: framework
+   */
 
-	/* clear style cache */
-	lua_pushnil(L);
-	lua_setfield(L, LUA_REGISTRYINDEX, "jiveStyleCache");
+  /* clear style cache */
+  lua_pushnil(L);
+  lua_setfield(L, LUA_REGISTRYINDEX, "jiveStyleCache");
 
-	/* bump layout counter */
-	next_jive_origin++;
+  /* bump layout counter */
+  next_jive_origin++;
 
-	/* redraw screen */
-	lua_pushcfunction(L, jiveL_redraw);
-	lua_pushvalue(L, 1);
-	lua_pushnil(L);
-	lua_call(L, 2, 0);
+  /* redraw screen */
+  lua_pushcfunction(L, jiveL_redraw);
+  lua_pushvalue(L, 1);
+  lua_pushnil(L);
+  lua_call(L, 2, 0);
 
-	return 0;
+  return 0;
 }
-
 
 void jive_queue_event(JiveEvent *evt) {
-	SDL_Event user_event;
-	user_event.type = SDL_USEREVENT;
+  SDL_Event user_event;
+  user_event.type = SDL_USEREVENT;
 
-	user_event.user.code = JIVE_USER_EVENT_EVENT;
-	user_event.user.data1 = malloc(sizeof(JiveEvent));
-	memcpy(user_event.user.data1, evt, sizeof(JiveEvent));
+  user_event.user.code = JIVE_USER_EVENT_EVENT;
+  user_event.user.data1 = malloc(sizeof(JiveEvent));
+  memcpy(user_event.user.data1, evt, sizeof(JiveEvent));
 
-	SDL_PushEvent(&user_event);
+  SDL_PushEvent(&user_event);
 }
 
-
 int jiveL_dispatch_event(lua_State *L) {
-	Uint32 r = 0;
-	Uint32 t0 = 0, t1 = 0;
-	clock_t c0 = 0, c1 = 0;
+  Uint32 r = 0;
+  Uint32 t0 = 0, t1 = 0;
+  clock_t c0 = 0, c1 = 0;
 
-	/* stack is:
-	 * 1: framework
-	 * 2: widget
-	 * 3: event
-	 */
+  /* stack is:
+   * 1: framework
+   * 2: widget
+   * 3: event
+   */
 
-	if (perfwarn.event) {
-		t0 = jive_jiffies();
-		c0 = clock();
-	}
+  if (perfwarn.event) {
+    t0 = jive_jiffies();
+    c0 = clock();
+  }
 
-	lua_pushcfunction(L, jive_traceback);  /* push traceback function */
+  lua_pushcfunction(L, jive_traceback); /* push traceback function */
 
-	// call global event listeners
-	if (jive_getmethod(L, 1, "_event")) {
-		lua_pushvalue(L, 1); // framework
-		lua_pushvalue(L, 3); // event
-		lua_pushboolean(L, 1); // global listeners
+  // call global event listeners
+  if (jive_getmethod(L, 1, "_event")) {
+    lua_pushvalue(L, 1);   // framework
+    lua_pushvalue(L, 3);   // event
+    lua_pushboolean(L, 1); // global listeners
 
-		if (lua_pcall(L, 3, 1, 4) != 0) {
-			LOG_WARN(log_ui_draw, "error in event function:\n\t%s\n", lua_tostring(L, -1));
-			return 0;
-		}
+    if (lua_pcall(L, 3, 1, 4) != 0) {
+      LOG_WARN(log_ui_draw, "error in event function:\n\t%s\n",
+               lua_tostring(L, -1));
+      return 0;
+    }
 
-		r |= lua_tointeger(L, -1);
-		lua_pop(L, 1);
-	}
+    r |= lua_tointeger(L, -1);
+    lua_pop(L, 1);
+  }
 
-	/* by default send the event to the top window. fetch that top
-	 * window here in case the global event handler has modified
-	 * the window stack.
-	 */
-	if (lua_isnil(L, 2)) {
-		lua_getfield(L, 1, "windowStack");
-		if (lua_objlen(L, -1) == 0) {
-			lua_pop(L, 1);
-			return 0;
-		}
-		lua_rawgeti(L, -1, 1);
-		lua_replace(L, 2);
-	}
+  /* by default send the event to the top window. fetch that top
+   * window here in case the global event handler has modified
+   * the window stack.
+   */
+  if (lua_isnil(L, 2)) {
+    lua_getfield(L, 1, "windowStack");
+    if (lua_objlen(L, -1) == 0) {
+      lua_pop(L, 1);
+      return 0;
+    }
+    lua_rawgeti(L, -1, 1);
+    lua_replace(L, 2);
+  }
 
-	// call widget event handler, unless the event is consumed
-	if (!(r & JIVE_EVENT_CONSUME) && jive_getmethod(L, 2, "_event")) {
-		lua_pushvalue(L, 2); // widget
-		lua_pushvalue(L, 3); // event
+  // call widget event handler, unless the event is consumed
+  if (!(r & JIVE_EVENT_CONSUME) && jive_getmethod(L, 2, "_event")) {
+    lua_pushvalue(L, 2); // widget
+    lua_pushvalue(L, 3); // event
 
-		if (lua_pcall(L, 2, 1, 4) != 0) {
-			LOG_WARN(log_ui_draw, "error in event function:\n\t%s\n", lua_tostring(L, -1));
-			return 0;
-		}
+    if (lua_pcall(L, 2, 1, 4) != 0) {
+      LOG_WARN(log_ui_draw, "error in event function:\n\t%s\n",
+               lua_tostring(L, -1));
+      return 0;
+    }
 
-		r |= lua_tointeger(L, -1);
-		lua_pop(L, 1);
-	}
+    r |= lua_tointeger(L, -1);
+    lua_pop(L, 1);
+  }
 
-	// call unused event listeners, unless the event is consumed
-	if (!(r & JIVE_EVENT_CONSUME) && jive_getmethod(L, 1, "_event")) {
-		lua_pushvalue(L, 1); // framework
-		lua_pushvalue(L, 3); // event
-		lua_pushboolean(L, 0); // unused listeners
+  // call unused event listeners, unless the event is consumed
+  if (!(r & JIVE_EVENT_CONSUME) && jive_getmethod(L, 1, "_event")) {
+    lua_pushvalue(L, 1);   // framework
+    lua_pushvalue(L, 3);   // event
+    lua_pushboolean(L, 0); // unused listeners
 
-		if (lua_pcall(L, 3, 1, 4) != 0) {
-			LOG_WARN(log_ui_draw, "error in event function:\n\t%s\n", lua_tostring(L, -1));
-			return 0;
-		}
+    if (lua_pcall(L, 3, 1, 4) != 0) {
+      LOG_WARN(log_ui_draw, "error in event function:\n\t%s\n",
+               lua_tostring(L, -1));
+      return 0;
+    }
 
-		r |= lua_tointeger(L, -1);
-		lua_pop(L, 1);
-	}
+    r |= lua_tointeger(L, -1);
+    lua_pop(L, 1);
+  }
 
-	if (perfwarn.event) {
-		t1 = jive_jiffies();
-		c1 = clock();
-		if (t1-t0 > perfwarn.event) {
-			printf("process_event > %dms: %4dms (%dms) ", perfwarn.event, t1-t0, (int)((c1-c0) * 1000 / CLOCKS_PER_SEC));
-			lua_getglobal(L, "tostring");
-			lua_pushvalue(L, 2);
-			lua_call(L, 1, 1);
-			lua_pushcfunction(L, jiveL_event_tostring);
-			lua_pushvalue(L, 3);
-			lua_call(L, 1, 1);
-			printf("[widget:%s event:%s]\n", lua_tostring(L, -2), lua_tostring(L, -1));
-			lua_pop(L, 2);
-		}
-	}
+  if (perfwarn.event) {
+    t1 = jive_jiffies();
+    c1 = clock();
+    if (t1 - t0 > perfwarn.event) {
+      printf("process_event > %dms: %4dms (%dms) ", perfwarn.event, t1 - t0,
+             (int)((c1 - c0) * 1000 / CLOCKS_PER_SEC));
+      lua_getglobal(L, "tostring");
+      lua_pushvalue(L, 2);
+      lua_call(L, 1, 1);
+      lua_pushcfunction(L, jiveL_event_tostring);
+      lua_pushvalue(L, 3);
+      lua_call(L, 1, 1);
+      printf("[widget:%s event:%s]\n", lua_tostring(L, -2),
+             lua_tostring(L, -1));
+      lua_pop(L, 2);
+    }
+  }
 
-	lua_pushinteger(L, r);
-	return 1;
+  lua_pushinteger(L, r);
+  return 1;
 }
 
 int jiveL_set_video_mode(lua_State *L) {
-	JiveSurface *srf;
-	Uint16 w, h, bpp;
-	bool isfull;
+  JiveSurface *srf;
+  Uint16 w, h, bpp;
+  bool isfull;
 
-	/* stack is:
-	 * 1: framework
-	 * 2: w
-	 * 3: h
-	 * 4: bpp
-	 * 5: fullscreen
-	 */
+  /* stack is:
+   * 1: framework
+   * 2: w
+   * 3: h
+   * 4: bpp
+   * 5: fullscreen
+   */
 
-	w = luaL_optinteger(L, 2, 0);
-	h = luaL_optinteger(L, 3, 0);
-	bpp = luaL_optinteger(L, 4, 16);
-	isfull = lua_toboolean(L, 5);
+  w = luaL_optinteger(L, 2, 0);
+  h = luaL_optinteger(L, 3, 0);
+  bpp = luaL_optinteger(L, 4, 16);
+  isfull = lua_toboolean(L, 5);
 
-	if (w == screen_w &&
-	    h == screen_h &&
-	    bpp == screen_bpp &&
-	    isfull == screen_isfull) {
-		return 0;
-	}
+  if (w == screen_w && h == screen_h && bpp == screen_bpp &&
+      isfull == screen_isfull) {
+    return 0;
+  }
 
+  /* update video mode */
+  srf = jive_surface_set_video_mode(w, h, bpp, isfull);
 
-	/* update video mode */
-	srf = jive_surface_set_video_mode(w, h, bpp, isfull);
+  /* store new screen surface */
+  lua_getfield(L, 1, "screen");
+  tolua_pushusertype(L, srf, "Surface");
+  lua_setfield(L, -2, "surface");
 
-	/* store new screen surface */
-	lua_getfield(L, 1, "screen");
-	tolua_pushusertype(L, srf, "Surface");
-	lua_setfield(L, -2, "surface");
+  lua_getfield(L, -1, "bounds");
+  lua_pushvalue(L, 2); /* width */
+  lua_rawseti(L, -2, 3);
+  lua_pushvalue(L, 3); /* height */
+  lua_rawseti(L, -2, 4);
+  lua_pop(L, 2);
 
-	lua_getfield(L, -1, "bounds");
-	lua_pushvalue(L, 2); /* width */
-	lua_rawseti(L, -2, 3);
-	lua_pushvalue(L, 3); /* height */
-	lua_rawseti(L, -2, 4);
-	lua_pop(L, 2);
+  screen_w = w;
+  screen_h = h;
+  screen_bpp = bpp;
+  screen_isfull = isfull;
 
-	screen_w = w;
-	screen_h = h;
-	screen_bpp = bpp;
-	screen_isfull = isfull;
+  next_jive_origin++;
 
-	next_jive_origin++;
-
-	return 0;
+  return 0;
 }
 
 int jiveL_get_background(lua_State *L) {
-	tolua_pushusertype(L, jive_background, "Tile");
-	return 1;
+  tolua_pushusertype(L, jive_background, "Tile");
+  return 1;
 }
 
 int jiveL_set_background(lua_State *L) {
-	/* stack is:
-	 * 1: framework
-	 * 2: background image (tile)
-	 */
-	if (jive_background) {
-		jive_tile_free(jive_background);
-	}
-	jive_background = jive_tile_ref(tolua_tousertype(L, 2, 0));
-	next_jive_origin++;
+  /* stack is:
+   * 1: framework
+   * 2: background image (tile)
+   */
+  if (jive_background) {
+    jive_tile_free(jive_background);
+  }
+  jive_background = jive_tile_ref(tolua_tousertype(L, 2, 0));
+  next_jive_origin++;
 
-	return 0;
+  return 0;
 }
 
 int jiveL_push_event(lua_State *L) {
 
-	/* stack is:
-	 * 1: framework
-	 * 2: JiveEvent
-	 */
+  /* stack is:
+   * 1: framework
+   * 2: JiveEvent
+   */
 
-	JiveEvent *evt;
-	if (lua_isnil(L, 2)) {
-		//nothing to do when no event is passed in
-		return 0;
-	}
+  JiveEvent *evt;
+  if (lua_isnil(L, 2)) {
+    // nothing to do when no event is passed in
+    return 0;
+  }
 
-	evt = lua_touserdata(L, 2);
-	jive_queue_event(evt);
+  evt = lua_touserdata(L, 2);
+  jive_queue_event(evt);
 
-	return 0;
-} 
+  return 0;
+}
 
 int jiveL_event(lua_State *L) {
-	int r = 0;
-	int listener_type;
-	int event_type;
+  int r = 0;
+  int listener_type;
+  int event_type;
 
-	/* stack is:
-	 * 1: framework
-	 * 2: event
-	 * 3: globalListeners if true, or unusedListeners
-	 */
+  /* stack is:
+   * 1: framework
+   * 2: event
+   * 3: globalListeners if true, or unusedListeners
+   */
 
-	lua_getfield(L, 2, "getType");
-	lua_pushvalue(L, 2);
-	lua_call(L, 1, 1);
-	event_type = lua_tointeger(L, -1);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "getType");
+  lua_pushvalue(L, 2);
+  lua_call(L, 1, 1);
+  event_type = lua_tointeger(L, -1);
+  lua_pop(L, 1);
 
-	listener_type = lua_toboolean(L, 3);
-	if (listener_type) {
-		lua_getfield(L, 1, "globalListeners");
-	}
-	else {
-		lua_getfield(L, 1, "unusedListeners");
-	}
-	lua_pushnil(L);
-	while (r == 0 && lua_next(L, -2) != 0) {
-		int mask;
+  listener_type = lua_toboolean(L, 3);
+  if (listener_type) {
+    lua_getfield(L, 1, "globalListeners");
+  } else {
+    lua_getfield(L, 1, "unusedListeners");
+  }
+  lua_pushnil(L);
+  while (r == 0 && lua_next(L, -2) != 0) {
+    int mask;
 
-		lua_rawgeti(L, -1, 1);
-		mask = lua_tointeger(L, -1);
+    lua_rawgeti(L, -1, 1);
+    mask = lua_tointeger(L, -1);
 
-		if (event_type & mask) {
-			lua_rawgeti(L, -2, 2);
-			lua_pushvalue(L, 2);
-			lua_call(L, 1, 1);
+    if (event_type & mask) {
+      lua_rawgeti(L, -2, 2);
+      lua_pushvalue(L, 2);
+      lua_call(L, 1, 1);
 
-			r = r | lua_tointeger(L, -1);
+      r = r | lua_tointeger(L, -1);
 
-			lua_pop(L, 1);
-		}
+      lua_pop(L, 1);
+    }
 
-		lua_pop(L, 2);
-	}
-	lua_pop(L, 1);
+    lua_pop(L, 2);
+  }
+  lua_pop(L, 1);
 
-	lua_pushinteger(L, r);
-	return 1;
+  lua_pushinteger(L, r);
+  return 1;
 }
-
 
 int jiveL_get_ticks(lua_State *L) {
-	lua_pushinteger(L, jive_jiffies());
-	return 1;
+  lua_pushinteger(L, jive_jiffies());
+  return 1;
 }
-
 
 int jiveL_thread_time(lua_State *L) {
-	lua_pushinteger(L, (int)(clock() * 1000 / CLOCKS_PER_SEC));
-	return 1;
+  lua_pushinteger(L, (int)(clock() * 1000 / CLOCKS_PER_SEC));
+  return 1;
 }
-
 
 static int do_dispatch_event(lua_State *L, JiveEvent *jevent) {
-	int r;
+  int r;
 
-	/* Send event to lua widgets */
-	r = JIVE_EVENT_UNUSED;
-	lua_pushcfunction(L, jiveL_dispatch_event);
-	jiveL_getframework(L);
-	lua_pushnil(L); // default to top window
-	jive_pushevent(L, jevent);
-	lua_call(L, 3, 1);
-	r = lua_tointeger(L, -1);
-	lua_pop(L, 1);
+  /* Send event to lua widgets */
+  r = JIVE_EVENT_UNUSED;
+  lua_pushcfunction(L, jiveL_dispatch_event);
+  jiveL_getframework(L);
+  lua_pushnil(L); // default to top window
+  jive_pushevent(L, jevent);
+  lua_call(L, 3, 1);
+  r = lua_tointeger(L, -1);
+  lua_pop(L, 1);
 
-	return r;
+  return r;
 }
-
 
 static int process_event(lua_State *L, SDL_Event *event) {
-	JiveEvent jevent;
-	Uint32 now;
+  JiveEvent jevent;
+  Uint32 now;
 
-	memset(&jevent, 0, sizeof(JiveEvent));
-	jevent.ticks = now = jive_jiffies();
+  memset(&jevent, 0, sizeof(JiveEvent));
+  jevent.ticks = now = jive_jiffies();
 
-	switch (event->type) {
-	case SDL_QUIT:
-		jiveL_quit(L);
-		exit(0);
-		break;
+  switch (event->type) {
+  case SDL_QUIT:
+    jiveL_quit(L);
+    exit(0);
+    break;
 
-	case SDL_MOUSEBUTTONDOWN:
-		/* map the mouse scroll wheel to up/down */
-		if (event->button.button == SDL_BUTTON_WHEELUP) {
-			jevent.type = JIVE_EVENT_SCROLL;
-			--(jevent.u.scroll.rel);
-			break;
-		}
-		else if (event->button.button == SDL_BUTTON_WHEELDOWN) {
-			jevent.type = JIVE_EVENT_SCROLL;
-			++(jevent.u.scroll.rel);
-			break;
-		}
+  case SDL_MOUSEBUTTONDOWN:
+    /* map the mouse scroll wheel to up/down */
+    if (event->button.button == SDL_BUTTON_WHEELUP) {
+      jevent.type = JIVE_EVENT_SCROLL;
+      --(jevent.u.scroll.rel);
+      break;
+    } else if (event->button.button == SDL_BUTTON_WHEELDOWN) {
+      jevent.type = JIVE_EVENT_SCROLL;
+      ++(jevent.u.scroll.rel);
+      break;
+    }
 
-		// Fall through
+    // Fall through
 
-	case SDL_MOUSEBUTTONUP:
-		if (event->button.button == SDL_BUTTON_LEFT) {
-			if (event->button.state == SDL_PRESSED) {
-				jevent.type = JIVE_EVENT_MOUSE_DOWN;
-				jevent.u.mouse.x = event->button.x;
-				jevent.u.mouse.y = event->button.y;
-			}
-			else {
-				jevent.type = JIVE_EVENT_MOUSE_UP;
-				jevent.u.mouse.x = event->button.x;
-				jevent.u.mouse.y = event->button.y;
-			}
-		}
+  case SDL_MOUSEBUTTONUP:
+    if (event->button.button == SDL_BUTTON_LEFT) {
+      if (event->button.state == SDL_PRESSED) {
+        jevent.type = JIVE_EVENT_MOUSE_DOWN;
+        jevent.u.mouse.x = event->button.x;
+        jevent.u.mouse.y = event->button.y;
+      } else {
+        jevent.type = JIVE_EVENT_MOUSE_UP;
+        jevent.u.mouse.x = event->button.x;
+        jevent.u.mouse.y = event->button.y;
+      }
+    }
 
-		if (event->type == SDL_MOUSEBUTTONDOWN) {
-			if (mouse_state == MOUSE_STATE_NONE) {
-				mouse_state = MOUSE_STATE_DOWN;
-				mouse_timeout_arg = (event->button.y << 16) | event->button.x;
-				mouse_timeout = now + HOLD_TIMEOUT;
-				mouse_long_timeout = now + LONG_HOLD_TIMEOUT;
+    if (event->type == SDL_MOUSEBUTTONDOWN) {
+      if (mouse_state == MOUSE_STATE_NONE) {
+        mouse_state = MOUSE_STATE_DOWN;
+        mouse_timeout_arg = (event->button.y << 16) | event->button.x;
+        mouse_timeout = now + HOLD_TIMEOUT;
+        mouse_long_timeout = now + LONG_HOLD_TIMEOUT;
 
-				mouse_origin_x = event->button.x;
-				mouse_origin_y = event->button.y;
-				break;
-			}
-		}
-		else /* SDL_MOUSEBUTTONUP */ {
-			if (mouse_state == MOUSE_STATE_DOWN) {
-				/*
-				 * MOUSE_PRESSED and MOUSE_UP events
-				 */
-				JiveEvent up;
+        mouse_origin_x = event->button.x;
+        mouse_origin_y = event->button.y;
+        break;
+      }
+    } else /* SDL_MOUSEBUTTONUP */ {
+      if (mouse_state == MOUSE_STATE_DOWN) {
+        /*
+         * MOUSE_PRESSED and MOUSE_UP events
+         */
+        JiveEvent up;
 
-				memset(&up, 0, sizeof(JiveEvent));
-				up.type = JIVE_EVENT_MOUSE_PRESS;
-				up.ticks = jive_jiffies();
-				up.u.mouse.x = event->button.x;
-				up.u.mouse.y = event->button.y;
-				do_dispatch_event(L, &up);
-			}
+        memset(&up, 0, sizeof(JiveEvent));
+        up.type = JIVE_EVENT_MOUSE_PRESS;
+        up.ticks = jive_jiffies();
+        up.u.mouse.x = event->button.x;
+        up.u.mouse.y = event->button.y;
+        do_dispatch_event(L, &up);
+      }
 
-			mouse_timeout = 0;
-			mouse_long_timeout = 0;
-			mouse_state = MOUSE_STATE_NONE;
-		}
-		break;
+      mouse_timeout = 0;
+      mouse_long_timeout = 0;
+      mouse_state = MOUSE_STATE_NONE;
+    }
+    break;
 
-	case SDL_MOUSEMOTION:
+  case SDL_MOUSEMOTION:
 
-		/* show mouse cursor */
-		if (pointer_timeout == 0) {
-			SDL_ShowCursor(SDL_ENABLE);
-		}
-		pointer_timeout = now + POINTER_TIMEOUT;
+    /* show mouse cursor */
+    if (pointer_timeout == 0) {
+      SDL_ShowCursor(SDL_ENABLE);
+    }
+    pointer_timeout = now + POINTER_TIMEOUT;
 
-		if (event->motion.state & SDL_BUTTON(1)) {
-			if ( (mouse_state == MOUSE_STATE_DOWN || mouse_state == MOUSE_STATE_SENT)) {
-				jevent.type = JIVE_EVENT_MOUSE_DRAG;
-				jevent.u.mouse.x = event->motion.x;
-				jevent.u.mouse.y = event->motion.y;
-			}
-		}
-		else {
-			jevent.type = JIVE_EVENT_MOUSE_MOVE;
-			jevent.u.mouse.x = event->motion.x;
-			jevent.u.mouse.y = event->motion.y;
-		}
-		break;
+    if (event->motion.state & SDL_BUTTON(1)) {
+      if ((mouse_state == MOUSE_STATE_DOWN ||
+           mouse_state == MOUSE_STATE_SENT)) {
+        jevent.type = JIVE_EVENT_MOUSE_DRAG;
+        jevent.u.mouse.x = event->motion.x;
+        jevent.u.mouse.y = event->motion.y;
+      }
+    } else {
+      jevent.type = JIVE_EVENT_MOUSE_MOVE;
+      jevent.u.mouse.x = event->motion.x;
+      jevent.u.mouse.y = event->motion.y;
+    }
+    break;
 
-	case SDL_KEYDOWN:
-		if (event->key.keysym.mod == KMOD_NONE || event->key.keysym.mod == KMOD_NUM) {
-			if (event->key.keysym.sym == SDLK_UP) {
-				jevent.type = JIVE_EVENT_SCROLL;
-				--(jevent.u.scroll.rel);
-				break;
-			}
-			else if (event->key.keysym.sym == SDLK_DOWN) {
-				jevent.type = JIVE_EVENT_SCROLL;
-				++(jevent.u.scroll.rel);
-				break;
-			}
-		}
-		// Fall through
+  case SDL_KEYDOWN:
+    if (event->key.keysym.mod == KMOD_NONE ||
+        event->key.keysym.mod == KMOD_NUM) {
+      if (event->key.keysym.sym == SDLK_UP) {
+        jevent.type = JIVE_EVENT_SCROLL;
+        --(jevent.u.scroll.rel);
+        break;
+      } else if (event->key.keysym.sym == SDLK_DOWN) {
+        jevent.type = JIVE_EVENT_SCROLL;
+        ++(jevent.u.scroll.rel);
+        break;
+      }
+    }
+    // Fall through
 
-	case SDL_KEYUP: {
-		struct jive_keymap *entry = keymap;
-		
-		if (event->key.keysym.mod & (KMOD_ALT|KMOD_MODE)) {
-			/* simulate IR input, using alt key */
-			struct jive_keyir *ir = irmap;
+  case SDL_KEYUP: {
+    struct jive_keymap *entry = keymap;
 
-			while (ir->keysym != SDLK_UNKNOWN) {
-				if (ir->keysym == event->key.keysym.sym) {
-					break;
-				}
-				ir++;
-			}
-			if (ir->keysym == SDLK_UNKNOWN) {
-				break;
-			}
+    if (event->key.keysym.mod & (KMOD_ALT | KMOD_MODE)) {
+      /* simulate IR input, using alt key */
+      struct jive_keyir *ir = irmap;
 
-			if (event->type == SDL_KEYDOWN) {
-				jevent.type = JIVE_EVENT_IR_DOWN;
-				jevent.u.ir.code = ir->code;
-			}
-			else {
-				JiveEvent irup;
+      while (ir->keysym != SDLK_UNKNOWN) {
+        if (ir->keysym == event->key.keysym.sym) {
+          break;
+        }
+        ir++;
+      }
+      if (ir->keysym == SDLK_UNKNOWN) {
+        break;
+      }
 
-				jevent.type = JIVE_EVENT_IR_PRESS;
-				jevent.u.ir.code = ir->code;
+      if (event->type == SDL_KEYDOWN) {
+        jevent.type = JIVE_EVENT_IR_DOWN;
+        jevent.u.ir.code = ir->code;
+      } else {
+        JiveEvent irup;
 
-				memset(&irup, 0, sizeof(JiveEvent));
-				irup.type = JIVE_EVENT_IR_UP;
-				irup.ticks = jive_jiffies();
-				irup.u.ir.code = ir->code;
-				jive_queue_event(&irup);
-			}
+        jevent.type = JIVE_EVENT_IR_PRESS;
+        jevent.u.ir.code = ir->code;
 
-			break;
-		}
+        memset(&irup, 0, sizeof(JiveEvent));
+        irup.type = JIVE_EVENT_IR_UP;
+        irup.ticks = jive_jiffies();
+        irup.u.ir.code = ir->code;
+        jive_queue_event(&irup);
+      }
 
-		while (entry->keysym != SDLK_UNKNOWN) {
-			if (entry->keysym == event->key.keysym.sym) {
-				break;
-			}
-			entry++;
-		}
+      break;
+    }
 
-		if (entry->keysym == SDLK_UNKNOWN) {
-			// handle regular character keys ('a', 't', etc..)
-			if (event->type == SDL_KEYDOWN && event->key.keysym.unicode != 0) {
-				jevent.type = JIVE_EVENT_CHAR_PRESS;
-				if (event->key.keysym.sym == SDLK_BACKSPACE) {
-					//special case for Backspace, where value set is not ascii value, instead pass backspace ascii value
-					jevent.u.text.unicode = 8;
-				} else {
-					jevent.u.text.unicode = event->key.keysym.unicode;
-				}
-			}
-		}
+    while (entry->keysym != SDLK_UNKNOWN) {
+      if (entry->keysym == event->key.keysym.sym) {
+        break;
+      }
+      entry++;
+    }
 
-		/* handle pgup/upgn as repeatable keys */
-		else if (entry->keysym == SDLK_PAGEUP || entry->keysym == SDLK_PAGEDOWN) {
-			if (event->type == SDL_KEYDOWN) {
-				jevent.type = JIVE_EVENT_KEY_PRESS;
-				jevent.ticks = jive_jiffies();
-				jevent.u.key.code = entry->keycode;
-			}
-		}
-		
-		else if (event->type == SDL_KEYDOWN) {
-			if (key_mask & entry->keycode) {
-				// ignore key repeats
-				return 0;
-			}
-			if (key_mask == 0) {
-				key_state = KEY_STATE_NONE;
-			}
+    if (entry->keysym == SDLK_UNKNOWN) {
+      // handle regular character keys ('a', 't', etc..)
+      if (event->type == SDL_KEYDOWN && event->key.keysym.unicode != 0) {
+        jevent.type = JIVE_EVENT_CHAR_PRESS;
+        if (event->key.keysym.sym == SDLK_BACKSPACE) {
+          // special case for Backspace, where value set is not ascii value,
+          // instead pass backspace ascii value
+          jevent.u.text.unicode = 8;
+        } else {
+          jevent.u.text.unicode = event->key.keysym.unicode;
+        }
+      }
+    }
 
-			switch (key_state) {
-			case KEY_STATE_NONE:
-				key_state = KEY_STATE_DOWN;
-				// fall through
+    /* handle pgup/upgn as repeatable keys */
+    else if (entry->keysym == SDLK_PAGEUP || entry->keysym == SDLK_PAGEDOWN) {
+      if (event->type == SDL_KEYDOWN) {
+        jevent.type = JIVE_EVENT_KEY_PRESS;
+        jevent.ticks = jive_jiffies();
+        jevent.u.key.code = entry->keycode;
+      }
+    }
 
-			case KEY_STATE_DOWN: {
-				key_mask |= entry->keycode;
+    else if (event->type == SDL_KEYDOWN) {
+      if (key_mask & entry->keycode) {
+        // ignore key repeats
+        return 0;
+      }
+      if (key_mask == 0) {
+        key_state = KEY_STATE_NONE;
+      }
 
-				jevent.type = JIVE_EVENT_KEY_DOWN;
-				jevent.u.key.code = entry->keycode;
+      switch (key_state) {
+      case KEY_STATE_NONE:
+        key_state = KEY_STATE_DOWN;
+        // fall through
 
-				key_timeout = now + HOLD_TIMEOUT;
-				break;
-			 }
+      case KEY_STATE_DOWN: {
+        key_mask |= entry->keycode;
 
-			case KEY_STATE_SENT:
-				break;
-			}
-		}
-		else /* SDL_KEYUP */ {
-			if (! (key_mask & entry->keycode)) {
-				// ignore repeated key ups
-				return 0;
-			}
+        jevent.type = JIVE_EVENT_KEY_DOWN;
+        jevent.u.key.code = entry->keycode;
 
-			switch (key_state) {
-			case KEY_STATE_NONE:
-				break;
+        key_timeout = now + HOLD_TIMEOUT;
+        break;
+      }
 
-			case KEY_STATE_DOWN: {
-				/*
-				 * KEY_PRESSED and KEY_UP events
-				 */
-				JiveEvent keyup;
+      case KEY_STATE_SENT:
+        break;
+      }
+    } else /* SDL_KEYUP */ {
+      if (!(key_mask & entry->keycode)) {
+        // ignore repeated key ups
+        return 0;
+      }
 
-				jevent.type = JIVE_EVENT_KEY_PRESS;
-				jevent.u.key.code = key_mask;
+      switch (key_state) {
+      case KEY_STATE_NONE:
+        break;
 
-				memset(&keyup, 0, sizeof(JiveEvent));
-				keyup.type = JIVE_EVENT_KEY_UP;
-				keyup.ticks = jive_jiffies();
-				keyup.u.key.code = entry->keycode;
-				jive_queue_event(&keyup);
+      case KEY_STATE_DOWN: {
+        /*
+         * KEY_PRESSED and KEY_UP events
+         */
+        JiveEvent keyup;
 
-				key_state = KEY_STATE_SENT;
-				break;
-			}
+        jevent.type = JIVE_EVENT_KEY_PRESS;
+        jevent.u.key.code = key_mask;
 
-			case KEY_STATE_SENT: {
-				/*
-				 * KEY_UP event
-				 */
-				jevent.type = JIVE_EVENT_KEY_UP;
-				jevent.u.key.code = entry->keycode;
-				break;
-			}
-			}
+        memset(&keyup, 0, sizeof(JiveEvent));
+        keyup.type = JIVE_EVENT_KEY_UP;
+        keyup.ticks = jive_jiffies();
+        keyup.u.key.code = entry->keycode;
+        jive_queue_event(&keyup);
 
-			key_timeout = 0;
-			key_mask &= ~(entry->keycode);
-			if (key_mask == 0) {
-				key_state = KEY_STATE_NONE;
-			}
-		}
-		break;
-	}
+        key_state = KEY_STATE_SENT;
+        break;
+      }
 
-	case SDL_USEREVENT:
-		assert(event->user.code == JIVE_USER_EVENT_EVENT);
+      case KEY_STATE_SENT: {
+        /*
+         * KEY_UP event
+         */
+        jevent.type = JIVE_EVENT_KEY_UP;
+        jevent.u.key.code = entry->keycode;
+        break;
+      }
+      }
 
-		memcpy(&jevent, event->user.data1, sizeof(JiveEvent));
-		free(event->user.data1);
-		break;
+      key_timeout = 0;
+      key_mask &= ~(entry->keycode);
+      if (key_mask == 0) {
+        key_state = KEY_STATE_NONE;
+      }
+    }
+    break;
+  }
 
-	case SDL_VIDEORESIZE: {
-		JiveSurface *srf;
-		int bpp = 16;
+  case SDL_USEREVENT:
+    assert(event->user.code == JIVE_USER_EVENT_EVENT);
 
-		screen_w = event->resize.w;
-		screen_h = event->resize.h;
+    memcpy(&jevent, event->user.data1, sizeof(JiveEvent));
+    free(event->user.data1);
+    break;
 
-		srf = jive_surface_set_video_mode(screen_w, screen_h, bpp, false);
+  case SDL_VIDEORESIZE: {
+    JiveSurface *srf;
+    int bpp = 16;
 
-		lua_getfield(L, 1, "screen");
+    screen_w = event->resize.w;
+    screen_h = event->resize.h;
 
-		lua_getfield(L, -1, "bounds");
-		lua_pushinteger(L, screen_w);
-		lua_rawseti(L, -2, 3);
-		lua_pushinteger(L, screen_h);
-		lua_rawseti(L, -2, 4);
-		lua_pop(L, 1);
+    srf = jive_surface_set_video_mode(screen_w, screen_h, bpp, false);
 
-		tolua_pushusertype(L, srf, "Surface");
-		lua_setfield(L, -2, "surface");
+    lua_getfield(L, 1, "screen");
 
-		lua_pop(L, 1);
+    lua_getfield(L, -1, "bounds");
+    lua_pushinteger(L, screen_w);
+    lua_rawseti(L, -2, 3);
+    lua_pushinteger(L, screen_h);
+    lua_rawseti(L, -2, 4);
+    lua_pop(L, 1);
 
-		next_jive_origin++;
+    tolua_pushusertype(L, srf, "Surface");
+    lua_setfield(L, -2, "surface");
 
-		jevent.type = JIVE_EVENT_WINDOW_RESIZE;
-		
-		/* Avoid mouse_up causing a mouse press event to occur */
-		mouse_state = MOUSE_STATE_NONE;
-		break;
+    lua_pop(L, 1);
 
-	}
+    next_jive_origin++;
 
-	default:
-		return 0;
-	}
+    jevent.type = JIVE_EVENT_WINDOW_RESIZE;
 
-	return do_dispatch_event(L, &jevent);
+    /* Avoid mouse_up causing a mouse press event to occur */
+    mouse_state = MOUSE_STATE_NONE;
+    break;
+  }
+
+  default:
+    return 0;
+  }
+
+  return do_dispatch_event(L, &jevent);
 }
-
 
 static void process_timers(lua_State *L) {
-	JiveEvent jevent;
-	Uint32 now;
+  JiveEvent jevent;
+  Uint32 now;
 
-	memset(&jevent, 0, sizeof(JiveEvent));
-	jevent.ticks = now = jive_jiffies();
+  memset(&jevent, 0, sizeof(JiveEvent));
+  jevent.ticks = now = jive_jiffies();
 
-	if (pointer_timeout && pointer_timeout < now) {
-		SDL_ShowCursor(SDL_DISABLE);
-		pointer_timeout = 0;
-	}
+  if (pointer_timeout && pointer_timeout < now) {
+    SDL_ShowCursor(SDL_DISABLE);
+    pointer_timeout = 0;
+  }
 
-	if (mouse_timeout && mouse_timeout < now) {
-		if (mouse_state == MOUSE_STATE_DOWN) {
-			jevent.type = JIVE_EVENT_MOUSE_HOLD;
-			jevent.u.mouse.x = (mouse_timeout_arg >> 0) & 0xFFFF;
-			jevent.u.mouse.y = (mouse_timeout_arg >> 16) & 0xFFFF;
-			mouse_state = MOUSE_STATE_SENT;
+  if (mouse_timeout && mouse_timeout < now) {
+    if (mouse_state == MOUSE_STATE_DOWN) {
+      jevent.type = JIVE_EVENT_MOUSE_HOLD;
+      jevent.u.mouse.x = (mouse_timeout_arg >> 0) & 0xFFFF;
+      jevent.u.mouse.y = (mouse_timeout_arg >> 16) & 0xFFFF;
+      mouse_state = MOUSE_STATE_SENT;
 
-			do_dispatch_event(L, &jevent);
-		}
-		mouse_timeout = 0;
-	}
+      do_dispatch_event(L, &jevent);
+    }
+    mouse_timeout = 0;
+  }
 
-	if (mouse_long_timeout && mouse_long_timeout < now) {
-		if (mouse_state == MOUSE_STATE_SENT) {
-			jevent.type = JIVE_EVENT_MOUSE_HOLD;
-			jevent.u.mouse.x = (mouse_timeout_arg >> 0) & 0xFFFF;
-			jevent.u.mouse.y = (mouse_timeout_arg >> 16) & 0xFFFF;
-			mouse_state = MOUSE_STATE_SENT;
+  if (mouse_long_timeout && mouse_long_timeout < now) {
+    if (mouse_state == MOUSE_STATE_SENT) {
+      jevent.type = JIVE_EVENT_MOUSE_HOLD;
+      jevent.u.mouse.x = (mouse_timeout_arg >> 0) & 0xFFFF;
+      jevent.u.mouse.y = (mouse_timeout_arg >> 16) & 0xFFFF;
+      mouse_state = MOUSE_STATE_SENT;
 
-			do_dispatch_event(L, &jevent);
-		}
-		mouse_long_timeout = 0;
-	}
+      do_dispatch_event(L, &jevent);
+    }
+    mouse_long_timeout = 0;
+  }
 
-	if (key_timeout && key_timeout < now) {
-		jevent.type = JIVE_EVENT_KEY_HOLD;
-		jevent.u.key.code = key_mask;
-		key_state = KEY_STATE_SENT;
+  if (key_timeout && key_timeout < now) {
+    jevent.type = JIVE_EVENT_KEY_HOLD;
+    jevent.u.key.code = key_mask;
+    key_state = KEY_STATE_SENT;
 
-		do_dispatch_event(L, &jevent);
+    do_dispatch_event(L, &jevent);
 
-		key_timeout = 0;
-	}
+    key_timeout = 0;
+  }
 }
-
 
 int jiveL_perfwarn(lua_State *L) {
-	/* stack is:
-	 * 1: framework
-	 * 2: table of threshold values, if no entry or 0 warnings are disabled 
-	 */
+  /* stack is:
+   * 1: framework
+   * 2: table of threshold values, if no entry or 0 warnings are disabled
+   */
 
-	if (lua_istable(L, 2)) {
-		lua_getfield(L, 2, "screen");
-		perfwarn.screen = lua_tointeger(L, -1);
-		lua_getfield(L, 2, "layout");
-		perfwarn.layout = lua_tointeger(L, -1);
-		lua_getfield(L, 2, "draw");
-		perfwarn.draw = lua_tointeger(L, -1);
-		lua_getfield(L, 2, "event");
-		perfwarn.event = lua_tointeger(L, -1);
-		lua_getfield(L, 2, "queue");
-		perfwarn.queue = lua_tointeger(L, -1);
-		lua_getfield(L, 2, "garbage");
-		perfwarn.garbage = lua_tointeger(L, -1);
-		lua_pop(L, 6);
-	}
-	
-	return 0;
+  if (lua_istable(L, 2)) {
+    lua_getfield(L, 2, "screen");
+    perfwarn.screen = lua_tointeger(L, -1);
+    lua_getfield(L, 2, "layout");
+    perfwarn.layout = lua_tointeger(L, -1);
+    lua_getfield(L, 2, "draw");
+    perfwarn.draw = lua_tointeger(L, -1);
+    lua_getfield(L, 2, "event");
+    perfwarn.event = lua_tointeger(L, -1);
+    lua_getfield(L, 2, "queue");
+    perfwarn.queue = lua_tointeger(L, -1);
+    lua_getfield(L, 2, "garbage");
+    perfwarn.garbage = lua_tointeger(L, -1);
+    lua_pop(L, 6);
+  }
+
+  return 0;
 }
 
-
 static const struct luaL_Reg icon_methods[] = {
-	{ "getPreferredBounds", jiveL_icon_get_preferred_bounds },
-	{ "setValue", jiveL_icon_set_value },
-	{ "_skin", jiveL_icon_skin },
-	{ "_layout", jiveL_icon_layout },
-	{ "draw", jiveL_icon_draw },
-	{ NULL, NULL }
-};
+    {"getPreferredBounds", jiveL_icon_get_preferred_bounds},
+    {"setValue", jiveL_icon_set_value},
+    {"_skin", jiveL_icon_skin},
+    {"_layout", jiveL_icon_layout},
+    {"draw", jiveL_icon_draw},
+    {NULL, NULL}};
 
 static const struct luaL_Reg label_methods[] = {
-	{ "getPreferredBounds", jiveL_label_get_preferred_bounds },
-	{ "_skin", jiveL_label_skin },
-	{ "_layout", jiveL_label_layout },
-	{ "animate", jiveL_label_animate },
-	{ "draw", jiveL_label_draw },
-	{ NULL, NULL }
-};
+    {"getPreferredBounds", jiveL_label_get_preferred_bounds},
+    {"_skin", jiveL_label_skin},
+    {"_layout", jiveL_label_layout},
+    {"animate", jiveL_label_animate},
+    {"draw", jiveL_label_draw},
+    {NULL, NULL}};
 
 static const struct luaL_Reg group_methods[] = {
-	{ "getPreferredBounds", jiveL_group_get_preferred_bounds },
-	{ "_skin", jiveL_group_skin },
-	{ "_layout", jiveL_group_layout },
-	{ "iterate", jiveL_group_iterate },
-	{ "draw", jiveL_group_draw },
-	{ NULL, NULL }
-};
+    {"getPreferredBounds", jiveL_group_get_preferred_bounds},
+    {"_skin", jiveL_group_skin},
+    {"_layout", jiveL_group_layout},
+    {"iterate", jiveL_group_iterate},
+    {"draw", jiveL_group_draw},
+    {NULL, NULL}};
 
 static const struct luaL_Reg textinput_methods[] = {
-	{ "getPreferredBounds", jiveL_textinput_get_preferred_bounds },
-	{ "_skin", jiveL_textinput_skin },
-	{ "_layout", jiveL_textinput_layout },
-	{ "draw", jiveL_textinput_draw },
-	{ NULL, NULL }
-};
+    {"getPreferredBounds", jiveL_textinput_get_preferred_bounds},
+    {"_skin", jiveL_textinput_skin},
+    {"_layout", jiveL_textinput_layout},
+    {"draw", jiveL_textinput_draw},
+    {NULL, NULL}};
 
 static const struct luaL_Reg menu_methods[] = {
-	{ "getPreferredBounds", jiveL_menu_get_preferred_bounds },
-	{ "_skin", jiveL_menu_skin },
-	{ "_layout", jiveL_menu_layout },
-	{ "iterate", jiveL_menu_iterate },
-	{ "draw", jiveL_menu_draw },
-	{ NULL, NULL }
-};
+    {"getPreferredBounds", jiveL_menu_get_preferred_bounds},
+    {"_skin", jiveL_menu_skin},
+    {"_layout", jiveL_menu_layout},
+    {"iterate", jiveL_menu_iterate},
+    {"draw", jiveL_menu_draw},
+    {NULL, NULL}};
 
 static const struct luaL_Reg slider_methods[] = {
-	{ "getPreferredBounds", jiveL_slider_get_preferred_bounds },
-	{ "getPillBounds", jiveL_slider_get_pill_bounds },
-	{ "_skin", jiveL_slider_skin },
-	{ "_layout", jiveL_slider_layout },
-	{ "draw", jiveL_slider_draw },
-	{ NULL, NULL }
-};
+    {"getPreferredBounds", jiveL_slider_get_preferred_bounds},
+    {"getPillBounds", jiveL_slider_get_pill_bounds},
+    {"_skin", jiveL_slider_skin},
+    {"_layout", jiveL_slider_layout},
+    {"draw", jiveL_slider_draw},
+    {NULL, NULL}};
 
 static const struct luaL_Reg textarea_methods[] = {
-	{ "getPreferredBounds", jiveL_textarea_get_preferred_bounds },
-	{ "_skin", jiveL_textarea_skin },
-	{ "invalidate", jiveL_textarea_invalidate },
-	{ "_layout", jiveL_textarea_layout },
-	{ "draw", jiveL_textarea_draw },
-	{ NULL, NULL }
-};
+    {"getPreferredBounds", jiveL_textarea_get_preferred_bounds},
+    {"_skin", jiveL_textarea_skin},
+    {"invalidate", jiveL_textarea_invalidate},
+    {"_layout", jiveL_textarea_layout},
+    {"draw", jiveL_textarea_draw},
+    {NULL, NULL}};
 
 static const struct luaL_Reg widget_methods[] = {
-	{ "setBounds", jiveL_widget_set_bounds }, 
-	{ "getBounds", jiveL_widget_get_bounds },
-	{ "getZOrder", jiveL_widget_get_z_order },
-	{ "isHidden", jiveL_widget_is_hidden },
-	{ "getPreferredBounds", jiveL_widget_get_preferred_bounds },
-	{ "getPadding", jiveL_widget_get_padding },
-	{ "getBorder", jiveL_widget_get_border },
-	{ "mouseBounds", jiveL_widget_mouse_bounds },
-	{ "mouseInside", jiveL_widget_mouse_inside },
-	{ "reSkin", jiveL_widget_reskin },
-	{ "reLayout", jiveL_widget_relayout },
-	{ "reDraw", jiveL_widget_redraw },
-	{ "checkSkin", jiveL_widget_check_skin },
-	{ "checkLayout", jiveL_widget_check_layout },
-	{ "peerToString", jiveL_widget_peer_tostring },
-	{ "stylePath", jiveL_style_path },
-	{ "styleValue", jiveL_style_value },
-	{ "styleInt", jiveL_style_value },
-	{ "styleColor", jiveL_style_color },
-	{ "styleArrayColor", jiveL_style_color },
-	{ "styleImage", jiveL_style_value },
-	{ "styleFont", jiveL_style_font },
-	{ NULL, NULL }
-};
+    {"setBounds", jiveL_widget_set_bounds},
+    {"getBounds", jiveL_widget_get_bounds},
+    {"getZOrder", jiveL_widget_get_z_order},
+    {"isHidden", jiveL_widget_is_hidden},
+    {"getPreferredBounds", jiveL_widget_get_preferred_bounds},
+    {"getPadding", jiveL_widget_get_padding},
+    {"getBorder", jiveL_widget_get_border},
+    {"mouseBounds", jiveL_widget_mouse_bounds},
+    {"mouseInside", jiveL_widget_mouse_inside},
+    {"reSkin", jiveL_widget_reskin},
+    {"reLayout", jiveL_widget_relayout},
+    {"reDraw", jiveL_widget_redraw},
+    {"checkSkin", jiveL_widget_check_skin},
+    {"checkLayout", jiveL_widget_check_layout},
+    {"peerToString", jiveL_widget_peer_tostring},
+    {"stylePath", jiveL_style_path},
+    {"styleValue", jiveL_style_value},
+    {"styleInt", jiveL_style_value},
+    {"styleColor", jiveL_style_color},
+    {"styleArrayColor", jiveL_style_color},
+    {"styleImage", jiveL_style_value},
+    {"styleFont", jiveL_style_font},
+    {NULL, NULL}};
 
 static const struct luaL_Reg window_methods[] = {
-	{ "_skin", jiveL_window_skin },
-	{ "checkLayout", jiveL_window_check_layout },
-	{ "iterate", jiveL_window_iterate },
-	{ "draw", jiveL_window_draw },
-	{ "_eventHandler", jiveL_window_event_handler },
-	{ NULL, NULL }
-};
+    {"_skin", jiveL_window_skin},
+    {"checkLayout", jiveL_window_check_layout},
+    {"iterate", jiveL_window_iterate},
+    {"draw", jiveL_window_draw},
+    {"_eventHandler", jiveL_window_event_handler},
+    {NULL, NULL}};
 
 static const struct luaL_Reg event_methods[] = {
-	{ "new", jiveL_event_new },
-	{ "getType", jiveL_event_get_type },
-	{ "getTicks", jiveL_event_get_ticks },
-	{ "getScroll", jiveL_event_get_scroll },
-	{ "getKeycode", jiveL_event_get_keycode },
-	{ "getUnicode", jiveL_event_get_unicode },
-	{ "getMouse", jiveL_event_get_mouse },
-	{ "getActionInternal", jiveL_event_get_action_internal },
-	{ "getMotion", jiveL_event_get_motion },
-	{ "getSwitch", jiveL_event_get_switch },
-	{ "getIRCode", jiveL_event_get_ircode },
-	{ "getGesture", jiveL_event_get_gesture },
-	{ "tostring", jiveL_event_tostring },
-	{ NULL, NULL }
-};
+    {"new", jiveL_event_new},
+    {"getType", jiveL_event_get_type},
+    {"getTicks", jiveL_event_get_ticks},
+    {"getScroll", jiveL_event_get_scroll},
+    {"getKeycode", jiveL_event_get_keycode},
+    {"getUnicode", jiveL_event_get_unicode},
+    {"getMouse", jiveL_event_get_mouse},
+    {"getActionInternal", jiveL_event_get_action_internal},
+    {"getMotion", jiveL_event_get_motion},
+    {"getSwitch", jiveL_event_get_switch},
+    {"getIRCode", jiveL_event_get_ircode},
+    {"getGesture", jiveL_event_get_gesture},
+    {"tostring", jiveL_event_tostring},
+    {NULL, NULL}};
 
 static const struct luaL_Reg core_methods[] = {
-	{ "initSDL", jiveL_initSDL },
-	{ "quit", jiveL_quit },
-	{ "processEvents", jiveL_process_events },
-	{ "setUpdateScreen", jiveL_set_update_screen },
-	{ "draw", jiveL_draw },
-	{ "updateScreen", jiveL_update_screen },
-	{ "reDraw", jiveL_redraw },
-	{ "pushEvent", jiveL_push_event },
-	{ "dispatchEvent", jiveL_dispatch_event },
-	{ "getTicks", jiveL_get_ticks },
-	{ "threadTime", jiveL_thread_time },
-	{ "setVideoMode", jiveL_set_video_mode },
-	{ "getBackground", jiveL_get_background },
-	{ "setBackground", jiveL_set_background },
-	{ "styleChanged", jiveL_style_changed },
-	{ "perfwarn", jiveL_perfwarn },
-	{ "_event", jiveL_event },
-	{ NULL, NULL }
-};
-
-
+    {"initSDL", jiveL_initSDL},
+    {"quit", jiveL_quit},
+    {"processEvents", jiveL_process_events},
+    {"setUpdateScreen", jiveL_set_update_screen},
+    {"draw", jiveL_draw},
+    {"updateScreen", jiveL_update_screen},
+    {"reDraw", jiveL_redraw},
+    {"pushEvent", jiveL_push_event},
+    {"dispatchEvent", jiveL_dispatch_event},
+    {"getTicks", jiveL_get_ticks},
+    {"threadTime", jiveL_thread_time},
+    {"setVideoMode", jiveL_set_video_mode},
+    {"getBackground", jiveL_get_background},
+    {"setBackground", jiveL_set_background},
+    {"styleChanged", jiveL_style_changed},
+    {"perfwarn", jiveL_perfwarn},
+    {"_event", jiveL_event},
+    {NULL, NULL}};
 
 static int jiveL_core_init(lua_State *L) {
 
-	lua_getglobal(L, "jive");
-	lua_getfield(L, -1, "ui");
+  lua_getglobal(L, "jive");
+  lua_getfield(L, -1, "ui");
 
-	/* stack is:
-	 * 1: jive table
-	 * 2: ui table
-	 */
+  /* stack is:
+   * 1: jive table
+   * 2: ui table
+   */
 
-	/* register methods */
-	lua_getfield(L, 2, "Icon");
-	luaL_register(L, NULL, icon_methods);
-	lua_pop(L, 1);
+  /* register methods */
+  lua_getfield(L, 2, "Icon");
+  luaL_register(L, NULL, icon_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Label");
-	luaL_register(L, NULL, label_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Label");
+  luaL_register(L, NULL, label_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Group");
-	luaL_register(L, NULL, group_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Group");
+  luaL_register(L, NULL, group_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Textinput");
-	luaL_register(L, NULL, textinput_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Textinput");
+  luaL_register(L, NULL, textinput_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Menu");
-	luaL_register(L, NULL, menu_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Menu");
+  luaL_register(L, NULL, menu_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Textarea");
-	luaL_register(L, NULL, textarea_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Textarea");
+  luaL_register(L, NULL, textarea_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Widget");
-	luaL_register(L, NULL, widget_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Widget");
+  luaL_register(L, NULL, widget_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Window");
-	luaL_register(L, NULL, window_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Window");
+  luaL_register(L, NULL, window_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Slider");
-	luaL_register(L, NULL, slider_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Slider");
+  luaL_register(L, NULL, slider_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Event");
-	luaL_register(L, NULL, event_methods);
-	lua_pop(L, 1);
+  lua_getfield(L, 2, "Event");
+  luaL_register(L, NULL, event_methods);
+  lua_pop(L, 1);
 
-	lua_getfield(L, 2, "Framework");
-	luaL_register(L, NULL, core_methods);
-	lua_pop(L, 1);
-	
-	return 0;
+  lua_getfield(L, 2, "Framework");
+  luaL_register(L, NULL, core_methods);
+  lua_pop(L, 1);
+
+  return 0;
 }
 
-static const struct luaL_Reg core_funcs[] = {
-	{ "frameworkOpen", jiveL_core_init },
-	{ NULL, NULL }
-};
+static const struct luaL_Reg core_funcs[] = {{"frameworkOpen", jiveL_core_init},
+                                             {NULL, NULL}};
 
 int luaopen_jive_ui_framework(lua_State *L) {
-	luaL_register(L, "jive", core_funcs);
-	return 1;
+  luaL_register(L, "jive", core_funcs);
+  return 1;
 }

--- a/src/squeezeplay/src/ui/lua_jiveui.pkg
+++ b/src/squeezeplay/src/ui/lua_jiveui.pkg
@@ -34,7 +34,7 @@ typedef unsigned int bool;
 #define true 1
 #define false !true
 
-#define JIVE_FRAME_RATE @ FRAME_RATE 20
+#define JIVE_FRAME_RATE @ FRAME_RATE 30
 
 #define JIVE_XY_NIL @ XY_NIL -1
 #define JIVE_WH_NIL @ WH_NIL 65535

--- a/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyApplet.lua
+++ b/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyApplet.lua
@@ -139,6 +139,11 @@ function init(self)
 	-- read uuid, serial and revision
 	parseCpuInfo(self)
 
+	-- Optimize ondemand governor for battery-aware responsiveness
+	log:info("Tuning ondemand governor for responsiveness...")
+	os.execute("echo 45 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold 2> /dev/null")
+	os.execute("echo 20000 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate 2> /dev/null")
+
 	System:init({
 		machine = "baby",
 		uuid = self._uuid,


### PR DESCRIPTION
A pull request for   several optimizations for the Squeezebox Radio..

- UI Snappiness: Increased frame rate to 30 FPS, reduced transitions to 200ms, and minimized redraw latency.
- System Stability: Extended watchdog timeout to 40s and added proactive memory management (GC) in Lua.
- Governor Tuning: Optimized ondemand settings for better responsiveness.
- Performance: added -ffunction-sections, -fdata-sections, and linker --gc-sections. This improves instruction cache locality and should further reduce binary size