### PR TITLE
Register player timezone with server for correct alarm scheduling

### DIFF
--- a/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyApplet.lua
+++ b/src/squeezeplay_baby/share/applets/SqueezeboxBaby/SqueezeboxBabyApplet.lua
@@ -715,6 +715,15 @@ function notify_playerCurrent(self, player)
 		player:getId(),
 		{ 'date', 'subscribe:3600' }
 	)
+
+	-- Register the device's timezone with the server so it can be used
+	-- when scheduling alarms. This is stored as a per-player preference
+	-- and read back by the server when building alarm menus.
+	local tz = squeezeos.getTimezone()
+	if tz then
+		log:info('Registering timezone with server: ', tz)
+		player:call({'playerpref', 'timezone', tz})
+	end
 end
 
 

--- a/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/SqueezeboxFab4Applet.lua
+++ b/src/squeezeplay_fab4/share/applets/SqueezeboxFab4/SqueezeboxFab4Applet.lua
@@ -505,6 +505,15 @@ function notify_playerCurrent(self, player)
 		player:getId(),
 		{ 'date', 'subscribe:3600' }
 	)
+
+	-- Register the device's timezone with the server so it can be used
+	-- when scheduling alarms. This is stored as a per-player preference
+	-- and read back by the server when building alarm menus.
+	local tz = squeezeos.getTimezone()
+	if tz then
+		log:info('Registering timezone with server: ', tz)
+		player:call({'playerpref', 'timezone', tz})
+	end
 end
 
 

--- a/src/squeezeplay_jive/share/applets/SqueezeboxJive/SqueezeboxJiveApplet.lua
+++ b/src/squeezeplay_jive/share/applets/SqueezeboxJive/SqueezeboxJiveApplet.lua
@@ -289,6 +289,15 @@ function notify_playerCurrent(self, player)
 		self.player:getId(),
 		{ 'date', 'subscribe:3600' }
 	)
+
+	-- Register the device's timezone with the server so it can be used
+	-- when scheduling alarms. This is stored as a per-player preference
+	-- and read back by the server when building alarm menus.
+	local tz = squeezeos.getTimezone()
+	if tz then
+		log:info('Registering timezone with server: ', tz)
+		player:call({'playerpref', 'timezone', tz})
+	end
 end
 
 function notify_playerDelete(self, player)

--- a/src/squeezeplay_squeezeos/share/applets/SetupTZ/SetupTZApplet.lua
+++ b/src/squeezeplay_squeezeos/share/applets/SetupTZ/SetupTZApplet.lua
@@ -7,6 +7,7 @@ local string                 = require("string")
 local squeezeos              = require("squeezeos_bsp")
 
 local Applet                 = require("jive.Applet")
+local Player                 = require("jive.slim.Player")
 local System                 = require("jive.System")
 local RadioGroup             = require("jive.ui.RadioGroup")
 local RadioButton            = require("jive.ui.RadioButton")
@@ -126,6 +127,13 @@ function settingsShow(self, menuItem)
 					local success,err = squeezeos.setTimezone(tzdata.olson)
 					if not success then
 						log:warn("setTimezone() failed: ", err)
+					else
+						-- Keep the server's per-player timezone preference in sync
+						-- so alarm scheduling uses the correct timezone.
+						local player = Player:getLocalPlayer()
+						if player then
+							player:call({'playerpref', 'timezone', tzdata.olson})
+						end
 					end
 				end,
 				enableme


### PR DESCRIPTION
Send the device's Olson timezone to the server as a per-player preference (playerpref timezone) when the player connects and whenever the user changes the timezone in Settings. The server reads this preference when building the Jive alarm menus and includes it in alarm add/update action params, so alarms are scheduled in the player's local timezone rather than the server's.

Requires LMS with the corresponding alarm timezone fix.