### PR TITLE
LocalPlayer: forward stateOnly parameter through _volumeNoIncrement

### DIFF
--- a/src/squeezeplay/share/jive/slim/LocalPlayer.lua
+++ b/src/squeezeplay/share/jive/slim/LocalPlayer.lua
@@ -323,8 +323,8 @@ function volume(self, vol, send)
 end
 
 
-function _volumeNoIncrement(self, vol, send)
-	self:volumeLocal(vol)
+function _volumeNoIncrement(self, vol, send, stateOnly)
+	self:volumeLocal(vol, nil, stateOnly)
 	return Player.volume(self, vol, send)
 end
 


### PR DESCRIPTION
## Problem

`_volumeNoIncrement` was silently dropping the `stateOnly` argument, so callers that only wanted to sync internal volume state (without triggering a hardware or server command) would incorrectly cause an actual volume change.

## Fix

Pass `stateOnly` through to `volumeLocal`.