### PR TITLE
AlarmSnooze: add Dismiss option to alarm popup

### DIFF
--- a/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
+++ b/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
@@ -696,13 +696,15 @@ function openAlarmWindow(self)
 			self:_alarmOff(true)
 			end,
 	})	
-	menu:addItem({
-		text = self:string("ALARM_SNOOZE_DISMISS"),
-		sound = "WINDOWHIDE",
-		callback = function()
-			self:_alarmDismiss()
-			end,
-	})
+	if self.server and self.server:isMoreRecent(self.server:getVersion(), '9.1.0') then
+		menu:addItem({
+			text = self:string("ALARM_SNOOZE_DISMISS"),
+			sound = "WINDOWHIDE",
+			callback = function()
+				self:_alarmDismiss()
+				end,
+		})
+	end
 	menu:setSelectedIndex(1)
 
 	local cancelAction = function()

--- a/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
+++ b/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
@@ -696,7 +696,7 @@ function openAlarmWindow(self)
 			self:_alarmOff(true)
 			end,
 	})	
-	if self.server and self.server:isMoreRecent(self.server:getVersion(), '9.1.0') then
+	if self.server and self.server:getVersion() and self.server:isMoreRecent(self.server:getVersion(), '9.1.0') then
 		menu:addItem({
 			text = self:string("ALARM_SNOOZE_DISMISS"),
 			sound = "WINDOWHIDE",

--- a/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
+++ b/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
@@ -414,6 +414,26 @@ function _alarmOff(self, stopStream)
 end
 
 
+function _alarmDismiss(self)
+	log:warn("*** Alarm: _alarmDismiss: dismissing alarm popup, leaving audio playing")
+
+	self:_silenceFallbackAlarm()
+	self.alarmInProgress = nil
+	self:_stopSnoozeTimer()
+	self:_stopDecodeStatePoller()
+
+	if self.alarmWindow then
+		self.alarmWindow:playSound("WINDOWHIDE")
+		self:_hideAlarmWindow()
+	end
+
+	-- Inform server: stop alarm state but leave audio and player state untouched
+	if self.localPlayer:isConnected() then
+		self.localPlayer:stopAlarm(true)
+	end
+end
+
+
 function soundFallbackAlarm(self)
 	log:warn("*** Alarm: soundFallbackAlarm()")
 	self.alarmVolume = 43 -- forget fade in stuff, just do it - it's an alarm!
@@ -676,6 +696,13 @@ function openAlarmWindow(self)
 			self:_alarmOff(true)
 			end,
 	})	
+	menu:addItem({
+		text = self:string("ALARM_SNOOZE_DISMISS"),
+		sound = "WINDOWHIDE",
+		callback = function()
+			self:_alarmDismiss()
+			end,
+	})
 	menu:setSelectedIndex(1)
 
 	local cancelAction = function()

--- a/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
+++ b/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
@@ -417,7 +417,11 @@ end
 function _alarmDismiss(self)
 	log:warn("*** Alarm: _alarmDismiss: dismissing alarm popup, leaving audio playing")
 
-	self:_silenceFallbackAlarm()
+	-- Don't call _silenceFallbackAlarm: it issues localPlayer:stop() which
+	-- kills the running alarm playlist. Only cancel the fallback timeout.
+	if self.fallbackAlarmTimeout and self.fallbackAlarmTimeout:isRunning() then
+		self.fallbackAlarmTimeout:stop()
+	end
 	self.alarmInProgress = nil
 	self:_stopSnoozeTimer()
 	self:_stopDecodeStatePoller()

--- a/src/squeezeplay/share/applets/AlarmSnooze/strings.txt
+++ b/src/squeezeplay/share/applets/AlarmSnooze/strings.txt
@@ -34,6 +34,11 @@ ALARM_SNOOZE_SNOOZE
 	RU	Повтор сигнала
 	SV	Snooze-funktion
 
+ALARM_SNOOZE_DISMISS
+# SLT: menu item to close the alarm popup without stopping playback
+	EN	Dismiss
+	NL	Sluiten
+
 ALARM_SNOOZE_TURN_OFF_ALARM
 	CS	Vypnout budík
 	DA	Sluk vækkeuret

--- a/src/squeezeplay/share/applets/AlarmSnooze/strings.txt
+++ b/src/squeezeplay/share/applets/AlarmSnooze/strings.txt
@@ -36,6 +36,7 @@ ALARM_SNOOZE_SNOOZE
 
 ALARM_SNOOZE_DISMISS
 # SLT: menu item to close the alarm popup without stopping playback
+	DE	Verwerfen
 	EN	Dismiss
 	NL	Sluiten
 

--- a/src/squeezeplay/share/applets/QVGAbaseSkin/QVGAbaseSkinApplet.lua
+++ b/src/squeezeplay/share/applets/QVGAbaseSkin/QVGAbaseSkinApplet.lua
@@ -1768,7 +1768,7 @@ function skin(self, s, reload, useDefaultSize)
 		fg = c.TEXT_COLOR,
 		sh = c.TEXT_SH_COLOR,
 		align = "center",
-		font = _boldfont(92),
+		font = _boldfont(72),
 	}
 	s.preview_text = _uses(s.alarm_time, {
 		font = _boldfont(c.TITLE_FONT_SIZE),
@@ -1794,9 +1794,9 @@ function skin(self, s, reload, useDefaultSize)
 			h = c.CM_MENU_HEIGHT * 5,
 			w = screenWidth - 34,
 			x = 7,
-			y = 18,
+			y = 22,
 			border = 0,
-			itemHeight = c.CM_MENU_HEIGHT,
+			itemHeight = 39,
 			position = LAYOUT_NORTH,
 			scrollbar = { 
 				h = c.CM_MENU_HEIGHT * 5 - 8,

--- a/src/squeezeplay/share/applets/QVGAbaseSkin/QVGAbaseSkinApplet.lua
+++ b/src/squeezeplay/share/applets/QVGAbaseSkin/QVGAbaseSkinApplet.lua
@@ -1794,7 +1794,7 @@ function skin(self, s, reload, useDefaultSize)
 			h = c.CM_MENU_HEIGHT * 5,
 			w = screenWidth - 34,
 			x = 7,
-			y = 53,
+			y = 12,
 			border = 0,
 			itemHeight = c.CM_MENU_HEIGHT,
 			position = LAYOUT_NORTH,

--- a/src/squeezeplay/share/applets/QVGAbaseSkin/QVGAbaseSkinApplet.lua
+++ b/src/squeezeplay/share/applets/QVGAbaseSkin/QVGAbaseSkinApplet.lua
@@ -1794,7 +1794,7 @@ function skin(self, s, reload, useDefaultSize)
 			h = c.CM_MENU_HEIGHT * 5,
 			w = screenWidth - 34,
 			x = 7,
-			y = 12,
+			y = 18,
 			border = 0,
 			itemHeight = c.CM_MENU_HEIGHT,
 			position = LAYOUT_NORTH,

--- a/src/squeezeplay/share/applets/QVGAportraitSkin/QVGAportraitSkinApplet.lua
+++ b/src/squeezeplay/share/applets/QVGAportraitSkin/QVGAportraitSkinApplet.lua
@@ -161,8 +161,6 @@ function skin(self, s, reload, useDefaultSize)
 	s.icon_battery_low.padding         = { 0, 42, 0, 0 }
 	s.waiting_popup.text.padding       = { 0, 42, 0, 0 }
 	s.waiting_popup.subtext.padding    = { 0, 0, 0, 46 }
-	s.alarm_time.font = _font(72)
-
 	s.toast_popup_mixed.text.font = _boldfont(14)
 	s.toast_popup_mixed.subtext.font = _boldfont(14)
 

--- a/src/squeezeplay/share/applets/WQVGAsmallSkin/WQVGAsmallSkinApplet.lua
+++ b/src/squeezeplay/share/applets/WQVGAsmallSkin/WQVGAsmallSkinApplet.lua
@@ -2214,7 +2214,7 @@ function skin(self, s)
 			h = CM_MENU_HEIGHT * 5,
 			w = screenWidth - 34,
 			x = 7,
-			y = 65,
+			y = 0,
 			border = 0,
 			itemHeight = CM_MENU_HEIGHT,
 			position = LAYOUT_NORTH,

--- a/src/squeezeplay/share/applets/WQVGAsmallSkin/WQVGAsmallSkinApplet.lua
+++ b/src/squeezeplay/share/applets/WQVGAsmallSkin/WQVGAsmallSkinApplet.lua
@@ -2214,7 +2214,7 @@ function skin(self, s)
 			h = CM_MENU_HEIGHT * 5,
 			w = screenWidth - 34,
 			x = 7,
-			y = 0,
+			y = 20,
 			border = 0,
 			itemHeight = CM_MENU_HEIGHT,
 			position = LAYOUT_NORTH,

--- a/src/squeezeplay/share/jive/slim/Player.lua
+++ b/src/squeezeplay/share/jive/slim/Player.lua
@@ -1496,7 +1496,7 @@ function unpause(self)
 	self:updateIconbar()
 end
 
--- optional continueAudio flag cancels alarm without pausing audio
+-- optional continueAudio flag cancels alarm without pausing audio or restoring player state
 function stopAlarm(self, continueAudio)
 	if not self.state then return end
 
@@ -1505,7 +1505,11 @@ function stopAlarm(self, continueAudio)
 	end
 
 	self.alarmState = 'none'
-	self:call({'jivealarm', 'stop:1'})
+	if continueAudio then
+		self:call({'jivealarm', 'stop:1', 'continueAudio:1'})
+	else
+		self:call({'jivealarm', 'stop:1'})
+	end
 	self:updateIconbar()
 
 end


### PR DESCRIPTION
## Summary

- Adds a third menu item **Dismiss** to the alarm popup alongside Snooze and Turn Off Alarm.
- Dismiss closes the popup without stopping playback or restoring the player's pre-alarm state (volume, power, shuffle).
- `stopAlarm()` gains an optional `continueAudio` parameter (default false). When true it skips the client-side pause and sends `continueAudio:1` to the server.
- Also fixes the existing `cancelAction` (Back button) path: it already passed `true` to `stopAlarm()` but the server was unconditionally restoring state anyway — the server-side fix is in the companion slimserver PR.

## Related

Companion PRs (independent):
- slimserver: https://github.com/LMS-Community/slimserver/pull/1564
- squeezeplay: https://github.com/ralph-irving/squeezeplay/pull/48